### PR TITLE
Import tourist attraction only in German language

### DIFF
--- a/Classes/Domain/Import/Converter/Organisation.php
+++ b/Classes/Domain/Import/Converter/Organisation.php
@@ -23,21 +23,38 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
+use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Import\Model\GenericEntity;
 
 class Organisation implements Converter
 {
-    public function convert(array $jsonIdOfEntity): GenericEntity
+    private Parser $parser;
+
+    public function __construct(
+        Parser $parser
+    ) {
+        $this->parser = $parser;
+    }
+
+    public function convert(array $jsonLD): EntityCollection
     {
-        return new GenericEntity(
+        $entity = GeneralUtility::makeInstance(
+            GenericEntity::class,
             10,
             'tx_thuecat_organisation',
-            $jsonIdOfEntity['@id'],
+            0,
+            $this->parser->getId($jsonLD),
             [
-                'title' => $jsonIdOfEntity['schema:name']['@value'],
-                'description' => $jsonIdOfEntity['schema:description']['@value'],
+                'title' => $this->parser->getTitle($jsonLD),
+                'description' => $this->parser->getDescription($jsonLD),
             ]
         );
+        $entities = GeneralUtility::makeInstance(EntityCollection::class);
+        $entities->add($entity);
+
+        return $entities;
     }
 
     public function canConvert(array $type): bool

--- a/Classes/Domain/Import/JsonLD/Parser.php
+++ b/Classes/Domain/Import/JsonLD/Parser.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\OpeningHours;
+
+class Parser
+{
+    private OpeningHours $openingHours;
+
+    public function __construct(
+        OpeningHours $openingHours
+    ) {
+        $this->openingHours = $openingHours;
+    }
+    public function getId(array $jsonLD): string
+    {
+        return $jsonLD['@id'];
+    }
+
+    public function getTitle(array $jsonLD, string $language = ''): string
+    {
+        return $this->getValueForLanguage($jsonLD['schema:name'], $language);
+    }
+
+    public function getDescription(array $jsonLD, string $language = ''): string
+    {
+        return $this->getValueForLanguage($jsonLD['schema:description'], $language);
+    }
+
+    public function getManagerId(array $jsonLD): string
+    {
+        return $jsonLD['thuecat:contentResponsible']['@id'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getContainedInPlaceIds(array $jsonLD): array
+    {
+        return array_map(function (array $place) {
+            return $place['@id'];
+        }, $jsonLD['schema:containedInPlace']);
+    }
+
+    public function getOpeningHours(array $jsonLD): array
+    {
+        return $this->openingHours->get($jsonLD);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLanguages(array $jsonLD): array
+    {
+        if (isset($jsonLD['schema:availableLanguage']) === false) {
+            return [];
+        }
+
+        $languages = $jsonLD['schema:availableLanguage'];
+
+        $languages = array_filter($languages, function (array $language) {
+            return isset($language['@type'])
+                && $language['@type'] === 'thuecat:Language'
+                ;
+        });
+
+        $languages = array_map(function (array $language) {
+            $language = $language['@value'];
+
+            if ($language === 'thuecat:German') {
+                return 'de';
+            }
+            if ($language === 'thuecat:English') {
+                return 'en';
+            }
+            if ($language === 'thuecat:French') {
+                return 'fr';
+            }
+
+            throw new \Exception('Unsupported language "' . $language . '".', 1612367481);
+        }, $languages);
+
+        return $languages;
+    }
+
+    private function getValueForLanguage(
+        array $property,
+        string $language
+    ): string {
+        if (
+            $this->doesLanguageMatch($property, $language)
+            && isset($property['@value'])
+        ) {
+            return $property['@value'];
+        }
+
+        foreach ($property as $languageEntry) {
+            if (
+                is_array($languageEntry)
+                && $this->doesLanguageMatch($languageEntry, $language)
+            ) {
+                return $languageEntry['@value'];
+            }
+        }
+
+        return '';
+    }
+
+    private function doesLanguageMatch(array $property, string $language): bool
+    {
+        return isset($property['@language'])
+            && (
+                $property['@language'] === $language
+                || $language === ''
+            )
+            ;
+    }
+}

--- a/Classes/Domain/Import/JsonLD/Parser/OpeningHours.php
+++ b/Classes/Domain/Import/JsonLD/Parser/OpeningHours.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+class OpeningHours
+{
+    public function get(array $jsonLD): array
+    {
+        $openingHours = $jsonLD['schema:openingHoursSpecification'] ?? [];
+        if ($openingHours === []) {
+            return [];
+        }
+
+        if (isset($openingHours['@id'])) {
+            return [$this->parseSingleEntry($openingHours)];
+        }
+
+        return array_values(array_map([$this, 'parseSingleEntry'], $openingHours));
+    }
+
+    private function parseSingleEntry(array $openingHour): array
+    {
+        return [
+            'opens' => $this->getOpens($openingHour),
+            'closes' => $this->getCloses($openingHour),
+            'from' => $this->getFrom($openingHour),
+            'through' => $this->getThrough($openingHour),
+            'daysOfWeek' => $this->getDaysOfWeek($openingHour),
+        ];
+    }
+
+    private function getOpens(array $openingHour): string
+    {
+        return $openingHour['schema:opens']['@value'] ?? '';
+    }
+
+    private function getCloses(array $openingHour): string
+    {
+        return $openingHour['schema:closes']['@value'] ?? '';
+    }
+
+    private function getFrom(array $openingHour): ?\DateTimeImmutable
+    {
+        if (isset($openingHour['schema:validFrom']['@value'])) {
+            return new \DateTimeImmutable($openingHour['schema:validFrom']['@value']);
+        }
+
+        return null;
+    }
+
+    private function getThrough(array $openingHour): ?\DateTimeImmutable
+    {
+        if (isset($openingHour['schema:validThrough']['@value'])) {
+            return new \DateTimeImmutable($openingHour['schema:validThrough']['@value']);
+        }
+
+        return null;
+    }
+
+    private function getDaysOfWeek(array $openingHour): array
+    {
+        if (isset($openingHour['schema:dayOfWeek']['@value'])) {
+            return [$this->getDayOfWeekString($openingHour['schema:dayOfWeek']['@value'])];
+        }
+        $daysOfWeek = array_map(function ($dayOfWeek) {
+            return $this->getDayOfWeekString($dayOfWeek['@value']);
+        }, $openingHour['schema:dayOfWeek'] ?? []);
+
+        sort($daysOfWeek);
+        return $daysOfWeek;
+    }
+
+    private function getDayOfWeekString(string $jsonLDValue): string
+    {
+        return str_replace(
+            'schema:',
+            '',
+            $jsonLDValue
+        );
+    }
+}

--- a/Classes/Domain/Import/Model/Entity.php
+++ b/Classes/Domain/Import/Model/Entity.php
@@ -29,6 +29,12 @@ interface Entity
 
     public function getTypo3DatabaseTableName(): string;
 
+    public function getTypo3SystemLanguageUid(): int;
+
+    public function isForDefaultLanguage(): bool;
+
+    public function isTranslation(): bool;
+
     /**
      * Return full remote id as delivered by remote API.
      */

--- a/Classes/Domain/Import/Model/EntityCollection.php
+++ b/Classes/Domain/Import/Model/EntityCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
+namespace WerkraumMedia\ThueCat\Domain\Import\Model;
 
 /*
  * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
@@ -23,19 +23,44 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  * 02110-1301, USA.
  */
 
-use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
-
-interface Converter
+class EntityCollection
 {
     /**
-     * A single type is an array of different types.
-     * All types together identify a specific entity and possible converter.
+     * @var Entity[]
      */
-    public function canConvert(array $type): bool;
+    private array $entities = [];
+
+    public function add(Entity $entity): void
+    {
+        $this->entities[] = $entity;
+    }
 
     /**
-     * A single JSONLD entity can have multiple languages.
-     * That may result in multiple entities in TYPO3.
+     * @return Entity[]
      */
-    public function convert(array $jsonLD): EntityCollection;
+    public function getEntities(): array
+    {
+        return $this->entities;
+    }
+
+    public function getDefaultLanguageEntity(): ?Entity
+    {
+        foreach ($this->entities as $entity) {
+            if ($entity->isForDefaultLanguage()) {
+                return $entity;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Entity[]
+     */
+    public function getTranslatedEntities(): array
+    {
+        return array_filter($this->entities, function (Entity $entity) {
+            return $entity->isTranslation();
+        });
+    }
 }

--- a/Classes/Domain/Import/Model/GenericEntity.php
+++ b/Classes/Domain/Import/Model/GenericEntity.php
@@ -27,6 +27,7 @@ class GenericEntity implements Entity
 {
     private int $typo3StoragePid;
     private string $typo3DatabaseTableName;
+    private int $typo3SystemLanguageUid;
     private bool $created = false;
     private int $typo3Uid = 0;
     private string $remoteId;
@@ -35,11 +36,13 @@ class GenericEntity implements Entity
     public function __construct(
         int $typo3StoragePid,
         string $typo3DatabaseTableName,
+        int $typo3SystemLanguageUid,
         string $remoteId,
         array $data
     ) {
         $this->typo3StoragePid = $typo3StoragePid;
         $this->typo3DatabaseTableName = $typo3DatabaseTableName;
+        $this->typo3SystemLanguageUid = $typo3SystemLanguageUid;
         $this->remoteId = $remoteId;
         $this->data = $data;
     }
@@ -52,6 +55,21 @@ class GenericEntity implements Entity
     public function getTypo3DatabaseTableName(): string
     {
         return $this->typo3DatabaseTableName;
+    }
+
+    public function getTypo3SystemLanguageUid(): int
+    {
+        return $this->typo3SystemLanguageUid;
+    }
+
+    public function isForDefaultLanguage(): bool
+    {
+        return $this->getTypo3SystemLanguageUid() === 0;
+    }
+
+    public function isTranslation(): bool
+    {
+        return $this->getTypo3SystemLanguageUid() !== 0;
     }
 
     public function getRemoteId(): string

--- a/Classes/Domain/Model/Backend/ImportLog.php
+++ b/Classes/Domain/Model/Backend/ImportLog.php
@@ -80,6 +80,7 @@ class ImportLog extends Typo3AbstractEntity
         foreach ($this->getEntries() as $entry) {
             if ($entry->hasErrors()) {
                 $errors = array_merge($errors, $entry->getErrors());
+                $errors = array_unique($errors);
             }
         }
 

--- a/Classes/Domain/Model/Backend/ImportLogEntry.php
+++ b/Classes/Domain/Model/Backend/ImportLogEntry.php
@@ -85,6 +85,7 @@ class ImportLogEntry extends Typo3AbstractEntity
     {
         if ($this->errorsAsArray === [] && $this->errors !== '') {
             $this->errorsAsArray = json_decode($this->errors, true);
+            $this->errorsAsArray = array_unique($this->errorsAsArray);
         }
 
         return $this->errorsAsArray;

--- a/Classes/Domain/Model/Frontend/OpeningHour.php
+++ b/Classes/Domain/Model/Frontend/OpeningHour.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Domain\Model\Frontend;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+class OpeningHour
+{
+    private string $opens;
+    private string $closes;
+    private array $daysOfWeek;
+    private ?\DateTimeImmutable $from;
+    private ?\DateTimeImmutable $through;
+
+    private function __construct(
+        string $opens,
+        string $closes,
+        array $daysOfWeek,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $through
+    ) {
+        $this->opens = $opens;
+        $this->closes = $closes;
+        $this->daysOfWeek = $daysOfWeek;
+        $this->from = $from;
+        $this->through = $through;
+    }
+
+    public static function createFromArray(array $rawData): self
+    {
+        $from = null;
+        if (isset($rawData['from'])) {
+            $timeZone = new \DateTimeZone($rawData['from']['timezone']);
+            $from = new \DateTimeImmutable($rawData['from']['date'], $timeZone);
+        }
+        $through = null;
+        if (isset($rawData['through'])) {
+            $timeZone = new \DateTimeZone($rawData['through']['timezone']);
+            $through = new \DateTimeImmutable($rawData['through']['date'], $timeZone);
+        }
+
+        return new self(
+            $rawData['opens'] ?? '',
+            $rawData['closes'] ?? '',
+            $rawData['daysOfWeek'] ?? '',
+            $from,
+            $through
+        );
+    }
+
+    public function getOpens(): string
+    {
+        return $this->opens;
+    }
+
+    public function getCloses(): string
+    {
+        return $this->closes;
+    }
+
+    public function getDaysOfWeek(): array
+    {
+        return $this->daysOfWeek;
+    }
+
+    public function getDaysOfWeekWithMondayFirstWeekDay(): array
+    {
+        return $this->sortedDaysOfWeek([
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday',
+            'Sunday',
+        ]);
+    }
+
+    public function getFrom(): ?\DateTimeImmutable
+    {
+        return $this->from;
+    }
+
+    public function getThrough(): ?\DateTimeImmutable
+    {
+        return $this->through;
+    }
+
+    private function sortedDaysOfWeek(array $sorting): array
+    {
+        if ($this->daysOfWeek === []) {
+            return [];
+        }
+
+        $days = [];
+
+        foreach ($sorting as $weekDay) {
+            $position = array_search($weekDay, $this->daysOfWeek);
+            if ($position === false) {
+                continue;
+            }
+
+            $days[] = $this->daysOfWeek[$position];
+        }
+
+        return $days;
+    }
+}

--- a/Classes/Domain/Model/Frontend/OpeningHours.php
+++ b/Classes/Domain/Model/Frontend/OpeningHours.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Domain\Model\Frontend;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use TYPO3\CMS\Core\Type\TypeInterface;
+
+/**
+ * @implements \Iterator<int, OpeningHour>
+ */
+class OpeningHours implements TypeInterface, \Iterator
+{
+    private string $serialized = '';
+    private array $array = [];
+    private int $position = 0;
+
+    public function __construct(string $serialized)
+    {
+        $this->serialized = $serialized;
+        $this->array = array_map(
+            [OpeningHour::class, 'createFromArray'],
+            json_decode($serialized, true)
+        );
+    }
+
+    public function __toString(): string
+    {
+        return $this->serialized;
+    }
+
+    public function current(): OpeningHour
+    {
+        return $this->array[$this->position];
+    }
+
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->array[$this->position]);
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+}

--- a/Classes/Domain/Model/Frontend/TouristAttraction.php
+++ b/Classes/Domain/Model/Frontend/TouristAttraction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
+namespace WerkraumMedia\ThueCat\Domain\Model\Frontend;
 
 /*
  * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
@@ -23,19 +23,32 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  * 02110-1301, USA.
  */
 
-use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
-interface Converter
+class TouristAttraction extends AbstractEntity
 {
-    /**
-     * A single type is an array of different types.
-     * All types together identify a specific entity and possible converter.
-     */
-    public function canConvert(array $type): bool;
+    protected string $title = '';
+    protected string $description = '';
+    protected ?OpeningHours $openingHours = null;
+    protected ?Town $town = null;
 
-    /**
-     * A single JSONLD entity can have multiple languages.
-     * That may result in multiple entities in TYPO3.
-     */
-    public function convert(array $jsonLD): EntityCollection;
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getOpeningHours(): ?OpeningHours
+    {
+        return $this->openingHours;
+    }
+
+    public function getTown(): ?Town
+    {
+        return $this->town;
+    }
 }

--- a/Classes/Domain/Model/Frontend/Town.php
+++ b/Classes/Domain/Model/Frontend/Town.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
+namespace WerkraumMedia\ThueCat\Domain\Model\Frontend;
 
 /*
  * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
@@ -23,19 +23,20 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  * 02110-1301, USA.
  */
 
-use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
-interface Converter
+class Town extends AbstractEntity
 {
-    /**
-     * A single type is an array of different types.
-     * All types together identify a specific entity and possible converter.
-     */
-    public function canConvert(array $type): bool;
+    protected string $title = '';
+    protected string $description = '';
 
-    /**
-     * A single JSONLD entity can have multiple languages.
-     * That may result in multiple entities in TYPO3.
-     */
-    public function convert(array $jsonLD): EntityCollection;
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
 }

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -23,6 +23,7 @@ namespace WerkraumMedia\ThueCat;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 use WerkraumMedia\ThueCat\Controller\Backend\ImportController;
 use WerkraumMedia\ThueCat\Controller\Backend\OverviewController;
@@ -32,6 +33,8 @@ class Extension
     public const EXTENSION_KEY = 'thuecat';
 
     public const EXTENSION_NAME = 'Thuecat';
+
+    public const TT_CONTENT_GROUP = 'thuecat';
 
     public static function getLanguagePath(): string
     {
@@ -55,5 +58,27 @@ class Extension
                 'labels' => self::getLanguagePath() . 'locallang_mod.xlf',
             ]
         );
+    }
+
+    public static function registerConfig(): void
+    {
+        $languagePath = self::getLanguagePath() . 'locallang_tca.xlf:tt_content';
+
+        // TODO: Add Icon
+        ExtensionManagementUtility::addPageTSConfig('
+            mod.wizards.newContentElement.wizardItems.thuecat {
+                header = ' . $languagePath . '.group
+                show = *
+                elements {
+                    thuecat_tourist_attraction{
+                        title = ' . $languagePath . '.thuecat_tourist_attraction
+                        description =  ' . $languagePath . '.thuecat_tourist_attraction.description
+                        tt_content_defValues {
+                            CType = thuecat_tourist_attraction
+                        }
+                    }
+                }
+            }
+        ');
     }
 }

--- a/Classes/Frontend/DataProcessing/ResolveEntities.php
+++ b/Classes/Frontend/DataProcessing/ResolveEntities.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Frontend\DataProcessing;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+
+class ResolveEntities implements DataProcessorInterface
+{
+    private ConnectionPool $connectionPool;
+    private DataMapper $dataMapper;
+
+    public function __construct(
+        ConnectionPool $connectionPool,
+        DataMapper $dataMapper
+    ) {
+        $this->connectionPool = $connectionPool;
+        $this->dataMapper = $dataMapper;
+    }
+
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData
+    ) {
+        $as = $cObj->stdWrapValue('as', $processorConfiguration, 'entities');
+        $table = $cObj->stdWrapValue('table', $processorConfiguration, '');
+        $uids = $cObj->stdWrapValue('uids', $processorConfiguration, '');
+
+        $uids = GeneralUtility::intExplode(',', $uids);
+        if ($uids === [] || $table === '') {
+            return $processedData;
+        }
+
+        $processedData[$as] = $this->resolveEntities($table, $uids);
+        return $processedData;
+    }
+
+    private function resolveEntities(string $table, array $uids): array
+    {
+        $targetType = '\WerkraumMedia\ThueCat\Domain\Model\Frontend\\' . $this->convertTableToEntity($table);
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $queryBuilder->select('*');
+        $queryBuilder->from($table);
+        $queryBuilder->where($queryBuilder->expr()->in(
+            'uid',
+            $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)
+        ));
+
+        return $this->dataMapper->map($targetType, $queryBuilder->execute()->fetchAll());
+    }
+
+    private function convertTableToEntity(string $table): string
+    {
+        $entityPart = str_replace('tx_thuecat_', '', $table);
+        return GeneralUtility::underscoredToUpperCamelCase($entityPart);
+    }
+}

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -19,4 +19,10 @@ return [
     \WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry::class => [
         'tableName' => 'tx_thuecat_import_log_entry',
     ],
+    \WerkraumMedia\ThueCat\Domain\Model\Frontend\TouristAttraction::class => [
+        'tableName' => 'tx_thuecat_tourist_attraction',
+    ],
+    \WerkraumMedia\ThueCat\Domain\Model\Frontend\Town::class => [
+        'tableName' => 'tx_thuecat_town',
+    ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,3 +10,7 @@ services:
   WerkraumMedia\ThueCat\Domain\Import\Importer\FetchData:
     arguments:
       $requestFactory: '@WerkraumMedia\ThueCat\Domain\Import\RequestFactory'
+
+  WerkraumMedia\ThueCat\Frontend\DataProcessing\:
+    resource: '../Classes/Frontend/DataProcessing/*'
+    public: true

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -3,7 +3,7 @@
 defined('TYPO3') or die();
 
 (static function (string $extensionKey, string $tableName) {
-    $languagePath = 'LLL:EXT:' . $extensionKey . '/Resources/Private/Language/locallang_be.xlf:' . $tableName . '.';
+    $languagePath = \WerkraumMedia\ThueCat\Extension::getLanguagePath() . 'locallang_be.xlf:' . $tableName . '.';
 
     \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['SiteConfiguration']['site'], [
         'columns' => [

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,14 @@
+<?php
+
+defined('TYPO3') or die();
+
+(static function (string $extensionKey, string $tableName) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+        $extensionKey,
+        'Configuration/TypoScript/',
+        'ThüCAT'
+    );
+})(
+    \WerkraumMedia\ThueCat\Extension::EXTENSION_KEY,
+    'sys_template'
+);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,18 @@
+<?php
+
+defined('TYPO3') or die();
+
+(static function (string $extensionKey, string $tableName) {
+    $languagePath = \WerkraumMedia\ThueCat\Extension::getLanguagePath()
+        . 'locallang_tca.xlf:' . $tableName;
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup(
+        $tableName,
+        'CType',
+        \WerkraumMedia\ThueCat\Extension::TT_CONTENT_GROUP,
+        $languagePath . '.group'
+    );
+})(
+    \WerkraumMedia\ThueCat\Extension::EXTENSION_KEY,
+    'tt_content'
+);

--- a/Configuration/TCA/Overrides/tt_content_tourist_attraction.php
+++ b/Configuration/TCA/Overrides/tt_content_tourist_attraction.php
@@ -1,0 +1,63 @@
+<?php
+
+defined('TYPO3') or die();
+
+(static function (string $extensionKey, string $tableName, string $cType) {
+    $languagePath = \WerkraumMedia\ThueCat\Extension::getLanguagePath()
+        . 'locallang_tca.xlf:' . $tableName . '.' . $cType;
+
+    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA'][$tableName], [
+        'ctrl' => [
+            // TODO: Add Icon
+            // 'typeicon_classes' => [
+            //     $cType => '',
+            // ],
+        ],
+        'types' => [
+            $cType => [
+                'showitem' =>
+                    '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,'
+                    . '--palette--;;general,'
+                    . '--palette--;;headers,'
+                    . 'records,'
+                    . '--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,'
+                    . '--palette--;;frames,'
+                    . '--palette--;;appearanceLinks,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,'
+                    . '--palette--;;language,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,'
+                    . '--palette--;;hidden,'
+                    . '--palette--;;access,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_category.tabs.category,'
+                    . 'categories,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,'
+                    . 'rowDescription,'
+                    . '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+                'columnsOverrides' => [
+                    'records' => [
+                        'config' => [
+                            'allowed' => 'tx_thuecat_tourist_attraction',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
+        $tableName,
+        'CType',
+        [
+            $languagePath,
+            $cType,
+            // TODO: Add Icon
+            '',
+            \WerkraumMedia\ThueCat\Extension::TT_CONTENT_GROUP,
+        ]
+    );
+})(
+    \WerkraumMedia\ThueCat\Extension::EXTENSION_KEY,
+    'tt_content',
+    'thuecat_tourist_attraction'
+);

--- a/Configuration/TCA/tx_thuecat_tourist_attraction.php
+++ b/Configuration/TCA/tx_thuecat_tourist_attraction.php
@@ -1,0 +1,89 @@
+<?php
+
+defined('TYPO3') or die();
+
+return (static function (string $extensionKey, string $tableName) {
+    $languagePath = \WerkraumMedia\ThueCat\Extension::getLanguagePath() . 'locallang_tca.xlf:' . $tableName;
+
+    return [
+        'ctrl' => [
+            'label' => 'title',
+            'default_sortby' => 'title',
+            'tstamp' => 'tstamp',
+            'crdate' => 'crdate',
+            'cruser_id' => 'cruser_id',
+            'title' => $languagePath,
+            'enablecolumns' => [
+                'disabled' => 'disable',
+            ],
+            'searchFields' => 'title, description',
+        ],
+        'columns' => [
+            'title' => [
+                'label' => $languagePath . '.title',
+                'config' => [
+                    'type' => 'input',
+                    'size' => 20,
+                    'max' => 255,
+                    'readOnly' => true,
+                ],
+            ],
+            'description' => [
+                'label' => $languagePath . '.description',
+                'config' => [
+                    'type' => 'text',
+                    'readOnly' => true,
+                ],
+            ],
+            'opening_hours' => [
+                'label' => $languagePath . '.opening_hours',
+                'config' => [
+                    'type' => 'text',
+                    'readOnly' => true,
+                ],
+            ],
+            'remote_id' => [
+                'label' => $languagePath . '.remote_id',
+                'config' => [
+                    'type' => 'input',
+                    'readOnly' => true,
+                ],
+            ],
+            'town' => [
+                'label' => $languagePath . '.town',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'foreign_table' => 'tx_thuecat_town',
+                    'items' => [
+                        [
+                            $languagePath . '.town.unkown',
+                            0,
+                        ],
+                    ],
+                    'readOnly' => true,
+                ],
+            ],
+            'managed_by' => [
+                'label' => $languagePath . '.managed_by',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'foreign_table' => 'tx_thuecat_organisation',
+                    'items' => [
+                        [
+                            $languagePath . '.managed_by.unkown',
+                            0,
+                        ],
+                    ],
+                    'readOnly' => true,
+                ],
+            ],
+        ],
+        'types' => [
+            '0' => [
+                'showitem' => 'title, description, opening_hours, remote_id, town, managed_by',
+            ],
+        ],
+    ];
+})(\WerkraumMedia\ThueCat\Extension::EXTENSION_KEY, 'tx_thuecat_tourist_attraction');

--- a/Configuration/TypoScript/Rendering.typoscript
+++ b/Configuration/TypoScript/Rendering.typoscript
@@ -1,0 +1,6 @@
+lib.thuecatContentElement =< lib.contentElement
+lib.thuecatContentElement {
+    templateRootPaths {
+        9999 = EXT:thuecat/Resources/Private/Templates/Frontend/ContentElement/
+    }
+}

--- a/Configuration/TypoScript/Rendering/TouristAttraction.typoscript
+++ b/Configuration/TypoScript/Rendering/TouristAttraction.typoscript
@@ -1,0 +1,13 @@
+tt_content {
+    thuecat_tourist_attraction =< lib.thuecatContentElement
+    thuecat_tourist_attraction {
+        templateName = TouristAttraction
+        dataProcessing {
+            10 = WerkraumMedia\ThueCat\Frontend\DataProcessing\ResolveEntities
+            10 {
+                table = tx_thuecat_tourist_attraction
+                uids.data = field:records
+            }
+        }
+    }
+}

--- a/Configuration/TypoScript/Rendering/_base.typoscript
+++ b/Configuration/TypoScript/Rendering/_base.typoscript
@@ -1,0 +1,6 @@
+lib.thuecatContentElement =< lib.contentElement
+lib.thuecatContentElement {
+    templateRootPaths {
+        9999 = EXT:thuecat/Resources/Private/Templates/Frontend/ContentElement/
+    }
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:thuecat/Configuration/TypoScript/Rendering/*.typoscript'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The extension already allows:
 
   * Tourist information
 
+  * Tourist attraction
+
 * Backend module:
 
   * To inspect current existing organisations
@@ -35,8 +37,6 @@ The extension already allows:
 ## Short time goals
 
 * Integrate proper icons
-
-* Import of tourist attraction
 
 * Content element to display tourist attraction,
   town, tourist information and organisation.

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -90,6 +90,9 @@
             <trans-unit id="module.imports.summary.tableName.tx_thuecat_tourist_information" xml:space="preserve">
                 <source>Tourist Information</source>
             </trans-unit>
+            <trans-unit id="module.imports.summary.tableName.tx_thuecat_tourist_attraction" xml:space="preserve">
+                <source>Tourist Attraction</source>
+            </trans-unit>
 
             <trans-unit id="controller.backend.import.import.success.title" xml:space="preserve">
                 <source>Import finished</source>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -72,6 +72,31 @@
                 <source>Unkown</source>
             </trans-unit>
 
+            <trans-unit id="tx_thuecat_tourist_attraction" xml:space="preserve">
+                <source>Tourist Attraction</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.title" xml:space="preserve">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.description" xml:space="preserve">
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.remote_id" xml:space="preserve">
+                <source>Remote ID</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.town" xml:space="preserve">
+                <source>Town</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.town.unkown" xml:space="preserve">
+                <source>Unkown</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.managed_by" xml:space="preserve">
+                <source>Managed by</source>
+            </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.managed_by.unkown" xml:space="preserve">
+                <source>Unkown</source>
+            </trans-unit>
+
             <trans-unit id="tx_thuecat_import_configuration" xml:space="preserve">
                 <source>Import Configuration</source>
             </trans-unit>
@@ -127,6 +152,16 @@
             </trans-unit>
             <trans-unit id="tx_thuecat_import_log_entry.crdate" xml:space="preserve">
                 <source>Created</source>
+            </trans-unit>
+
+            <trans-unit id="tt_content.group" xml:space="preserve">
+                <source>ThüCAT</source>
+            </trans-unit>
+            <trans-unit id="tt_content.thuecat_tourist_attraction" xml:space="preserve">
+                <source>Tourist Attraction</source>
+            </trans-unit>
+            <trans-unit id="tt_content.thuecat_tourist_attraction.description" xml:space="preserve">
+                <source>Renders selected tourist attractions</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Templates/Frontend/ContentElement/TouristAttraction.html
+++ b/Resources/Private/Templates/Frontend/ContentElement/TouristAttraction.html
@@ -1,0 +1,21 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+    <f:for each="{entities}" as="entity">
+        <div class="card" style="width: 18rem;">
+            <div class="card-body">
+                <h5 class="card-title">{entity.title} ({entity.town.title})</h5>
+                <p class="card-text">{entity.description}</p>
+
+                <f:for each="{entity.openingHours}" as="openingHour">
+                    <p>
+                        <f:for each="{openingHour.daysOfWeekWithMondayFirstWeekDay}" as="weekday">
+                            {weekday}: {openingHour.opens} - {openingHour.closes}<br>
+                        </f:for>
+                        {openingHour.from -> f:format.date(format: 'd.m.Y')} -
+                        {openingHour.through -> f:format.date(format: 'd.m.Y')}
+                    </p>
+                </f:for>
+            </div>
+        </div>
+    </f:for>
+</html>

--- a/Tests/Unit/Domain/Import/JsonLD/Parser/OpeningHoursTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/Parser/OpeningHoursTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD\Parser;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use PHPUnit\Framework\TestCase;
+use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\OpeningHours;
+
+/**
+ * @covers WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\OpeningHours
+ */
+class OpeningHoursTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function canBeCreated(): void
+    {
+        $subject = new OpeningHours();
+
+        self::assertInstanceOf(OpeningHours::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsEmptyArrayIfOpeningHoursAreMissing(): void
+    {
+        $subject = new OpeningHours();
+
+        $result = $subject->get([
+        ]);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsSingleOpeningHourWrappedInArray(): void
+    {
+        $subject = new OpeningHours();
+
+        $result = $subject->get([
+            'schema:openingHoursSpecification' => [
+                '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+                'schema:opens' => [
+                    '@type' => 'schema:Time',
+                    '@value' => '10:00:00',
+                ],
+                'schema:closes' => [
+                    '@type' => 'schema:Time',
+                    '@value' => '18:00:00',
+                ],
+                'schema:validFrom' => [
+                    '@type' => 'schema:Date',
+                    '@value' => '2021-03-01',
+                ],
+                'schema:validThrough' => [
+                    '@type' => 'schema:Date',
+                    '@value' => '2021-12-31',
+                ],
+                'schema:dayOfWeek' => [
+                    0 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Saturday',
+                    ],
+                    1 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Sunday',
+                    ],
+                    2 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Friday',
+                    ],
+                    3 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Thursday',
+                    ],
+                    4 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Tuesday',
+                    ],
+                    5 => [
+                        '@type' => 'schema:DayOfWeek',
+                        '@value' => 'schema:Wednesday',
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertSame('10:00:00', $result[0]['opens']);
+        self::assertSame('18:00:00', $result[0]['closes']);
+        self::assertSame([
+            'Friday',
+            'Saturday',
+            'Sunday',
+            'Thursday',
+            'Tuesday',
+            'Wednesday',
+        ], $result[0]['daysOfWeek']);
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[0]['from']);
+        self::assertSame('2021-03-01 00:00:00', $result[0]['from']->format('Y-m-d H:i:s'));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[0]['through']);
+        self::assertSame('2021-12-31 00:00:00', $result[0]['through']->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsSingleWeekDay(): void
+    {
+        $subject = new OpeningHours();
+
+        $result = $subject->get([
+            'schema:openingHoursSpecification' => [
+                '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+                'schema:dayOfWeek' => [
+                    '@type' => 'schema:DayOfWeek',
+                    '@value' => 'schema:Saturday',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertSame([
+            'Saturday',
+        ], $result[0]['daysOfWeek']);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsMultipleOpeningHours(): void
+    {
+        $subject = new OpeningHours();
+
+        $result = $subject->get([
+            'schema:openingHoursSpecification' => [
+                [
+                    '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+                    'schema:opens' => [
+                        '@type' => 'schema:Time',
+                        '@value' => '10:00:00',
+                    ],
+                    'schema:closes' => [
+                        '@type' => 'schema:Time',
+                        '@value' => '18:00:00',
+                    ],
+                    'schema:validFrom' => [
+                        '@type' => 'schema:Date',
+                        '@value' => '2021-03-01',
+                    ],
+                    'schema:validThrough' => [
+                        '@type' => 'schema:Date',
+                        '@value' => '2021-12-31',
+                    ],
+                    'schema:dayOfWeek' => [
+                        0 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Saturday',
+                        ],
+                        1 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Sunday',
+                        ],
+                        2 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Friday',
+                        ],
+                        3 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Thursday',
+                        ],
+                        4 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Tuesday',
+                        ],
+                        5 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Wednesday',
+                        ],
+                    ],
+                ],
+                [
+                    '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+                    'schema:opens' => [
+                        '@type' => 'schema:Time',
+                        '@value' => '09:00:00',
+                    ],
+                    'schema:closes' => [
+                        '@type' => 'schema:Time',
+                        '@value' => '17:00:00',
+                    ],
+                    'schema:validFrom' => [
+                        '@type' => 'schema:Date',
+                        '@value' => '2022-03-01',
+                    ],
+                    'schema:validThrough' => [
+                        '@type' => 'schema:Date',
+                        '@value' => '2022-12-31',
+                    ],
+                    'schema:dayOfWeek' => [
+                        0 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Saturday',
+                        ],
+                        1 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Sunday',
+                        ],
+                        2 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Friday',
+                        ],
+                        3 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Thursday',
+                        ],
+                        4 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Tuesday',
+                        ],
+                        5 => [
+                            '@type' => 'schema:DayOfWeek',
+                            '@value' => 'schema:Wednesday',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $result);
+
+        self::assertSame('10:00:00', $result[0]['opens']);
+        self::assertSame('18:00:00', $result[0]['closes']);
+        self::assertSame([
+            'Friday',
+            'Saturday',
+            'Sunday',
+            'Thursday',
+            'Tuesday',
+            'Wednesday',
+        ], $result[0]['daysOfWeek']);
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[0]['from']);
+        self::assertSame('2021-03-01 00:00:00', $result[0]['from']->format('Y-m-d H:i:s'));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[0]['through']);
+        self::assertSame('2021-12-31 00:00:00', $result[0]['through']->format('Y-m-d H:i:s'));
+
+        self::assertSame('09:00:00', $result[1]['opens']);
+        self::assertSame('17:00:00', $result[1]['closes']);
+        self::assertSame([
+            'Friday',
+            'Saturday',
+            'Sunday',
+            'Thursday',
+            'Tuesday',
+            'Wednesday',
+        ], $result[1]['daysOfWeek']);
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[1]['from']);
+        self::assertSame('2022-03-01 00:00:00', $result[1]['from']->format('Y-m-d H:i:s'));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $result[1]['through']);
+        self::assertSame('2022-12-31 00:00:00', $result[1]['through']->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsProperDefaultsOnMissingValues(): void
+    {
+        $subject = new OpeningHours();
+
+        $result = $subject->get([
+            'schema:openingHoursSpecification' => [
+                '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+            ],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertSame('', $result[0]['opens']);
+        self::assertSame('', $result[0]['closes']);
+        self::assertSame([], $result[0]['daysOfWeek']);
+        self::assertSame(null, $result[0]['from']);
+        self::assertSame(null, $result[0]['through']);
+    }
+}

--- a/Tests/Unit/Domain/Import/JsonLD/ParserTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/ParserTest.php
@@ -1,0 +1,457 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
+use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\OpeningHours;
+
+/**
+ * @covers WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser
+ */
+class ParserTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function canBeCreated(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+
+        self::assertInstanceOf(Parser::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsId(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+        $result = $subject->getId([
+            '@id' => 'https://example.com/resources/165868194223-id',
+        ]);
+
+        self::assertSame('https://example.com/resources/165868194223-id', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsManagerId(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+        $result = $subject->getManagerId([
+            'thuecat:contentResponsible' => [
+                '@id' => 'https://example.com/resources/165868194223-manager',
+            ],
+        ]);
+
+        self::assertSame('https://example.com/resources/165868194223-manager', $result);
+    }
+
+    /**
+     * @test
+     * @dataProvider titles
+     */
+    public function returnsTitle(array $jsonLD, string $language, string $expected): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+        $result = $subject->getTitle($jsonLD, $language);
+        self::assertSame($expected, $result);
+    }
+
+    public function titles(): array
+    {
+        return [
+            'json has multiple lanugages, one matches' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Title',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Title',
+                        ],
+                    ],
+                ],
+                'language' => 'de',
+                'expected' => 'DE Title',
+            ],
+            'json has multiple lanugages, no language specified' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Title',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Title',
+                        ],
+                    ],
+                ],
+                'language' => '',
+                'expected' => 'DE Title',
+            ],
+            'json has multiple languages, none matches' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Title',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Title',
+                        ],
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json has multiple languages, missing @language key' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        [
+                            '@value' => 'DE Title',
+                        ],
+                        [
+                            '@value' => 'FR Title',
+                        ],
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json has single language, that one matches' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Title',
+                    ],
+                ],
+                'language' => 'de',
+                'expected' => 'DE Title',
+            ],
+            'json contains single language, but another is requested' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Title',
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json contains single language, no language specified' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Title',
+                    ],
+                ],
+                'language' => '',
+                'expected' => 'DE Title',
+            ],
+            'json contains single language, missing @language key' => [
+                'jsonLD' => [
+                    'schema:name' => [
+                        '@value' => 'DE Title',
+                    ],
+                ],
+                'language' => '',
+                'expected' => '',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider descriptions
+     */
+    public function returnsDescription(array $jsonLD, string $language, string $expected): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+        $result = $subject->getDescription($jsonLD, $language);
+        self::assertSame($expected, $result);
+    }
+
+    public function descriptions(): array
+    {
+        return [
+            'json has multiple lanugages, one matches' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Description',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Description',
+                        ],
+                    ],
+                ],
+                'language' => 'de',
+                'expected' => 'DE Description',
+            ],
+            'json has multiple lanugages, no language specified' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Description',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Description',
+                        ],
+                    ],
+                ],
+                'language' => '',
+                'expected' => 'DE Description',
+            ],
+            'json has multiple languages, none matches' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        [
+                            '@language' => 'de',
+                            '@value' => 'DE Description',
+                        ],
+                        [
+                            '@language' => 'fr',
+                            '@value' => 'FR Description',
+                        ],
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json has multiple languages, missing @language key' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        [
+                            '@value' => 'DE Description',
+                        ],
+                        [
+                            '@value' => 'FR Description',
+                        ],
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json has single language, that one matches' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Description',
+                    ],
+                ],
+                'language' => 'de',
+                'expected' => 'DE Description',
+            ],
+            'json contains single language, but another is requested' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Description',
+                    ],
+                ],
+                'language' => 'en',
+                'expected' => '',
+            ],
+            'json contains single language, no language specified' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        '@language' => 'de',
+                        '@value' => 'DE Description',
+                    ],
+                ],
+                'language' => '',
+                'expected' => 'DE Description',
+            ],
+            'json contains single language, missing @language key' => [
+                'jsonLD' => [
+                    'schema:description' => [
+                        '@value' => 'DE Description',
+                    ],
+                ],
+                'language' => '',
+                'expected' => '',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function returnsContainedInPlaceIds(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+        $result = $subject->getContainedInPlaceIds([
+            'schema:containedInPlace' => [
+                ['@id' => 'https://thuecat.org/resources/043064193523-jcyt'],
+                ['@id' => 'https://thuecat.org/resources/349986440346-kbkf'],
+                ['@id' => 'https://thuecat.org/resources/794900260253-wjab'],
+                ['@id' => 'https://thuecat.org/resources/476888881990-xpwq'],
+                ['@id' => 'https://thuecat.org/resources/573211638937-gmqb'],
+            ],
+        ]);
+        self::assertSame([
+            'https://thuecat.org/resources/043064193523-jcyt',
+            'https://thuecat.org/resources/349986440346-kbkf',
+            'https://thuecat.org/resources/794900260253-wjab',
+            'https://thuecat.org/resources/476888881990-xpwq',
+            'https://thuecat.org/resources/573211638937-gmqb',
+        ], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsLanguages(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+
+        $result = $subject->getLanguages([
+            'schema:availableLanguage' => [
+                0 => [
+                    '@type' => 'thuecat:Language',
+                    '@value' => 'thuecat:German',
+                ],
+                1 => [
+                    '@type' => 'thuecat:Language',
+                    '@value' => 'thuecat:English',
+                ],
+                2 => [
+                    '@type' => 'thuecat:Language',
+                    '@value' => 'thuecat:French',
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            'de',
+            'en',
+            'fr',
+        ], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function throwsExceptionOnUnkownLanguage(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+
+        $this->expectExceptionCode(1612367481);
+        $result = $subject->getLanguages([
+            'schema:availableLanguage' => [
+                0 => [
+                    '@type' => 'thuecat:Language',
+                    '@value' => 'thuecat:Unkown',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsNoLanguagesIfInfoIsMissing(): void
+    {
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+
+        $result = $subject->getLanguages([]);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsOpeningHours(): void
+    {
+        $jsonLD = [
+            'schema:openingHoursSpecification' => [
+                '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b13',
+                'schema:opens' => [
+                    '@type' => 'schema:Time',
+                    '@value' => '10:00:00',
+                ],
+            ],
+        ];
+        $generatedOpeningHours = [
+            'opens' => '10:00:00',
+            'closes' => '',
+            'from' => null,
+            'through' => null,
+            'daysOfWeek' => [],
+        ];
+
+        $openingHours = $this->prophesize(OpeningHours::class);
+        $openingHours->get($jsonLD)->willReturn($generatedOpeningHours);
+
+        $subject = new Parser(
+            $openingHours->reveal()
+        );
+
+        $result = $subject->getOpeningHours($jsonLD);
+
+        self::assertSame($generatedOpeningHours, $result);
+    }
+}

--- a/Tests/Unit/Domain/Import/Model/EntityCollectionTest.php
+++ b/Tests/Unit/Domain/Import/Model/EntityCollectionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\Model;
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use WerkraumMedia\ThueCat\Domain\Import\Model\Entity;
+use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
+
+/**
+ * @covers WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection
+ */
+class EntityCollectionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function canBeCreated(): void
+    {
+        $subject = new EntityCollection();
+
+        self::assertInstanceOf(EntityCollection::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsEmptyArrayAsDefaultEntities(): void
+    {
+        $subject = new EntityCollection();
+
+        self::assertSame([], $subject->getEntities());
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFirstEntityForDefaultLanguage(): void
+    {
+        $entityWithTranslation = $this->prophesize(Entity::class);
+        $entityWithTranslation->isForDefaultLanguage()->willReturn(false);
+
+        $entityWithDefaultLanguage = $this->prophesize(Entity::class);
+        $entityWithDefaultLanguage->isForDefaultLanguage()->willReturn(true);
+
+        $subject = new EntityCollection();
+        $subject->add($entityWithTranslation->reveal());
+        $subject->add($entityWithDefaultLanguage->reveal());
+
+        self::assertSame(
+            $entityWithDefaultLanguage->reveal(),
+            $subject->getDefaultLanguageEntity()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function returnsNullIfNoEntityForDefaultLanguageExists(): void
+    {
+        $entityWithTranslation = $this->prophesize(Entity::class);
+        $entityWithTranslation->isForDefaultLanguage()->willReturn(false);
+
+        $subject = new EntityCollection();
+        $subject->add($entityWithTranslation->reveal());
+
+        self::assertSame(
+            null,
+            $subject->getDefaultLanguageEntity()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function returnsAllTranslatedEntities(): void
+    {
+        $entityWithTranslation1 = $this->prophesize(Entity::class);
+        $entityWithTranslation1->isTranslation()->willReturn(true);
+        $entityWithTranslation2 = $this->prophesize(Entity::class);
+        $entityWithTranslation2->isTranslation()->willReturn(true);
+        $entitiyWithDefaultLanguage = $this->prophesize(Entity::class);
+        $entitiyWithDefaultLanguage->isTranslation()->willReturn(false);
+
+        $subject = new EntityCollection();
+        $subject->add($entityWithTranslation1->reveal());
+        $subject->add($entitiyWithDefaultLanguage->reveal());
+        $subject->add($entityWithTranslation2->reveal());
+
+        self::assertSame(
+            [
+                0 => $entityWithTranslation1->reveal(),
+                2 => $entityWithTranslation2->reveal(),
+            ],
+            $subject->getTranslatedEntities()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function returnsEmptyArrayIfNoTranslatedEntityExists(): void
+    {
+        $entitiyWithDefaultLanguage = $this->prophesize(Entity::class);
+        $entitiyWithDefaultLanguage->isTranslation()->willReturn(false);
+
+        $subject = new EntityCollection();
+        $subject->add($entitiyWithDefaultLanguage->reveal());
+
+        self::assertSame(
+            [],
+            $subject->getTranslatedEntities()
+        );
+    }
+}

--- a/Tests/Unit/Domain/Import/Model/GenericEntityTest.php
+++ b/Tests/Unit/Domain/Import/Model/GenericEntityTest.php
@@ -39,6 +39,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             []
         );
@@ -53,6 +54,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             10,
             '',
+            0,
             '',
             []
         );
@@ -67,10 +69,56 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             'tx_thuecat_entity',
+            0,
             '',
             []
         );
         self::assertSame('tx_thuecat_entity', $subject->getTypo3DatabaseTableName());
+    }
+
+    /**
+     * @test
+     */
+    public function returnsTypo3SystemLanguageUid(): void
+    {
+        $subject = new GenericEntity(
+            0,
+            '',
+            10,
+            '',
+            []
+        );
+        self::assertSame(10, $subject->getTypo3SystemLanguageUid());
+    }
+
+    /**
+     * @test
+     */
+    public function claimsIsForDefaultLanguage(): void
+    {
+        $subject = new GenericEntity(
+            0,
+            '',
+            0,
+            '',
+            []
+        );
+        self::assertTrue($subject->isForDefaultLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function claimsIsTranslation(): void
+    {
+        $subject = new GenericEntity(
+            0,
+            '',
+            10,
+            '',
+            []
+        );
+        self::assertTrue($subject->isTranslation());
     }
 
     /**
@@ -81,6 +129,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             'https://example.com/resources/333039283321-xxwg',
             []
         );
@@ -98,6 +147,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             [
                 'column_name_1' => 'value 1',
@@ -121,6 +171,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             []
         );
@@ -138,6 +189,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             []
         );
@@ -155,6 +207,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             []
         );
@@ -172,6 +225,7 @@ class GenericEntityTest extends TestCase
         $subject = new GenericEntity(
             0,
             '',
+            0,
             '',
             []
         );

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "symfony/dependency-injection": "^5.2",
         "typo3/cms-backend": "^10.4",
         "typo3/cms-core": "^10.4",
-        "typo3/cms-extbase": "^10.4"
+        "typo3/cms-extbase": "^10.4",
+        "typo3/cms-frontend": "^10.4"
     },
     "require-dev": {
         "friendsoftypo3/phpstan-typo3": "^0.6.0",

--- a/dependency-checker.json
+++ b/dependency-checker.json
@@ -5,6 +5,7 @@
         "Configuration/SiteConfiguration/Overrides/*.php",
         "Configuration/TCA/*.php",
         "ext_emconf.php",
+        "ext_localconf.php",
         "ext_tables.php"
     ]
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,5 @@
+<?php
+
+defined('TYPO3') or die();
+
+\WerkraumMedia\ThueCat\Extension::registerConfig();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -40,3 +40,12 @@ CREATE TABLE tx_thuecat_tourist_information (
     title varchar(255) DEFAULT '' NOT NULL,
     description text DEFAULT '' NOT NULL,
 );
+
+CREATE TABLE tx_thuecat_tourist_attraction (
+    remote_id varchar(255) DEFAULT '' NOT NULL,
+    managed_by int(11) unsigned DEFAULT '0' NOT NULL,
+    town int(11) unsigned DEFAULT '0' NOT NULL,
+    title varchar(255) DEFAULT '' NOT NULL,
+    description text DEFAULT '' NOT NULL,
+    opening_hours text DEFAULT '' NOT NULL,
+);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,27 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: Classes/Domain/Import/Importer/SaveData.php
+
+		-
+			message: "#^Property WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\ImportLog\\:\\:\\$logEntries \\(iterable\\<WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\ImportLogEntry\\>&TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\) does not accept TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Backend/ImportLog.php
+
+		-
+			message: "#^Cannot call method getFirst\\(\\) on array\\|TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\.$#"
+			count: 1
+			path: Classes/Domain/Repository/Backend/TownRepository.php
+
+		-
+			message: "#^Method WerkraumMedia\\\\ThueCat\\\\Domain\\\\Repository\\\\Backend\\\\TownRepository\\:\\:findOneByRemoteIds\\(\\) should return WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\Town\\|null but returns object\\.$#"
+			count: 1
+			path: Classes/Domain/Repository/Backend/TownRepository.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: Classes/Frontend/DataProcessing/ResolveEntities.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - vendor/friendsoftypo3/phpstan-typo3/extension.neon
+    - phpstan-baseline.neon
 parameters:
     level: max
     paths:
@@ -8,20 +9,3 @@ parameters:
         - Tests
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: true
-    ignoreErrors:
-        -
-            message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
-            count: 1
-            path: Classes/Domain/Import/Importer/SaveData.php
-        -
-            message: "#^Property WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\ImportLog\\:\\:\\$logEntries \\(iterable\\<WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\ImportLogEntry\\>&TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\) does not accept TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\.$#"
-            count: 1
-            path: Classes/Domain/Model/Backend/ImportLog.php
-        -
-            message: "#^Cannot call method getFirst\\(\\) on array\\|TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\.$#"
-            count: 1
-            path: Classes/Domain/Repository/Backend/TownRepository.php
-        -
-            message: "#^Method WerkraumMedia\\\\ThueCat\\\\Domain\\\\Repository\\\\Backend\\\\TownRepository\\:\\:findOneByRemoteIds\\(\\) should return WerkraumMedia\\\\ThueCat\\\\Domain\\\\Model\\\\Backend\\\\Town\\|null but returns object\\.$#"
-            count: 1
-            path: Classes/Domain/Repository/Backend/TownRepository.php


### PR DESCRIPTION
Allows to import entity of type TouristAttraction.
Right now only in German, as this is most important.
Add output of tourist attraction via custom content element.