### PR TITLE
Remove deprecated CGL sets

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -27,8 +27,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters->set(Option::SETS, [
         SetList::PSR_12,
-        SetList::PHP_70,
-        SetList::PHP_73_MIGRATION,
         SetList::PHPUNIT,
     ]);
 


### PR DESCRIPTION
Actually they were meant as code migration, which should happen via
rector.