### PR TITLE
Fix two bugs: Language handling and price structure

### DIFF
--- a/Classes/Domain/Import/Converter/Organisation.php
+++ b/Classes/Domain/Import/Converter/Organisation.php
@@ -24,6 +24,7 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Import\Model\GenericEntity;
@@ -32,15 +33,20 @@ use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
 class Organisation implements Converter
 {
     private Parser $parser;
+    private LanguageHandling $language;
 
     public function __construct(
-        Parser $parser
+        Parser $parser,
+        LanguageHandling $language
     ) {
         $this->parser = $parser;
+        $this->language = $language;
     }
 
     public function convert(array $jsonLD, ImportConfiguration $configuration): EntityCollection
     {
+        $language = $this->language->getDefaultLanguage($configuration->getStoragePid());
+
         $entity = GeneralUtility::makeInstance(
             GenericEntity::class,
             $configuration->getStoragePid(),
@@ -48,8 +54,8 @@ class Organisation implements Converter
             0,
             $this->parser->getId($jsonLD),
             [
-                'title' => $this->parser->getTitle($jsonLD),
-                'description' => $this->parser->getDescription($jsonLD),
+                'title' => $this->parser->getTitle($jsonLD, $language),
+                'description' => $this->parser->getDescription($jsonLD, $language),
             ]
         );
         $entities = GeneralUtility::makeInstance(EntityCollection::class);

--- a/Classes/Domain/Import/Converter/TouristAttraction.php
+++ b/Classes/Domain/Import/Converter/TouristAttraction.php
@@ -62,8 +62,9 @@ class TouristAttraction implements Converter
         $entities = GeneralUtility::makeInstance(EntityCollection::class);
         $storagePid = $configuration->getStoragePid();
 
-        foreach ($this->parser->getLanguages($jsonLD) as $language) {
-            if ($this->language->isUnknown($language, $storagePid)) {
+        foreach ($this->language->getLanguages($storagePid) as $language) {
+            $title = $this->parser->getTitle($jsonLD, $language);
+            if ($title === '') {
                 continue;
             }
 
@@ -71,7 +72,7 @@ class TouristAttraction implements Converter
                 GenericEntity::class,
                 $storagePid,
                 'tx_thuecat_tourist_attraction',
-                $this->language->getSystemUid($language, $storagePid),
+                $language->getLanguageId(),
                 $this->parser->getId($jsonLD),
                 [
                     'title' => $this->parser->getTitle($jsonLD, $language),

--- a/Classes/Domain/Import/Converter/TouristInformation.php
+++ b/Classes/Domain/Import/Converter/TouristInformation.php
@@ -24,6 +24,7 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Import\Model\GenericEntity;
@@ -34,21 +35,25 @@ use WerkraumMedia\ThueCat\Domain\Repository\Backend\TownRepository;
 class TouristInformation implements Converter
 {
     private Parser $parser;
+    private LanguageHandling $language;
     private OrganisationRepository $organisationRepository;
     private TownRepository $townRepository;
 
     public function __construct(
         Parser $parser,
+        LanguageHandling $language,
         OrganisationRepository $organisationRepository,
         TownRepository $townRepository
     ) {
         $this->parser = $parser;
+        $this->language = $language;
         $this->organisationRepository = $organisationRepository;
         $this->townRepository = $townRepository;
     }
 
     public function convert(array $jsonLD, ImportConfiguration $configuration): EntityCollection
     {
+        $language = $this->language->getDefaultLanguage($configuration->getStoragePid());
         $manager = $this->organisationRepository->findOneByRemoteId(
             $this->parser->getManagerId($jsonLD)
         );
@@ -63,8 +68,8 @@ class TouristInformation implements Converter
             0,
             $this->parser->getId($jsonLD),
             [
-                'title' => $this->parser->getTitle($jsonLD),
-                'description' => $this->parser->getDescription($jsonLD),
+                'title' => $this->parser->getTitle($jsonLD, $language),
+                'description' => $this->parser->getDescription($jsonLD, $language),
                 'managed_by' => $manager ? $manager->getUid() : 0,
                 'town' => $town ? $town->getUid() : 0,
             ]

--- a/Classes/Domain/Import/Converter/Town.php
+++ b/Classes/Domain/Import/Converter/Town.php
@@ -24,6 +24,7 @@ namespace WerkraumMedia\ThueCat\Domain\Import\Converter;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Import\Model\GenericEntity;
@@ -33,18 +34,22 @@ use WerkraumMedia\ThueCat\Domain\Repository\Backend\OrganisationRepository;
 class Town implements Converter
 {
     private Parser $parser;
+    private LanguageHandling $language;
     private OrganisationRepository $organisationRepository;
 
     public function __construct(
         Parser $parser,
+        LanguageHandling $language,
         OrganisationRepository $organisationRepository
     ) {
         $this->parser = $parser;
+        $this->language = $language;
         $this->organisationRepository = $organisationRepository;
     }
 
     public function convert(array $jsonLD, ImportConfiguration $configuration): EntityCollection
     {
+        $language = $this->language->getDefaultLanguage($configuration->getStoragePid());
         $manager = $this->organisationRepository->findOneByRemoteId(
             $this->parser->getManagerId($jsonLD)
         );
@@ -56,8 +61,8 @@ class Town implements Converter
             0,
             $this->parser->getId($jsonLD),
             [
-                'title' => $this->parser->getTitle($jsonLD),
-                'description' => $this->parser->getDescription($jsonLD),
+                'title' => $this->parser->getTitle($jsonLD, $language),
+                'description' => $this->parser->getDescription($jsonLD, $language),
                 'managed_by' => $manager ? $manager->getUid() : 0,
             ]
         );

--- a/Classes/Domain/Import/Importer/LanguageHandling.php
+++ b/Classes/Domain/Import/Importer/LanguageHandling.php
@@ -34,31 +34,16 @@ class LanguageHandling
         $this->siteFinder = $siteFinder;
     }
 
-    public function isUnknown(string $languageIsoCode, int $pageUid): bool
-    {
-        $availableIsoCodes = array_map(function (SiteLanguage $language) {
-            return $language->getTwoLetterIsoCode();
-        }, $this->getLanguages($pageUid));
-
-        return in_array($languageIsoCode, $availableIsoCodes) === false;
-    }
-
-    public function getSystemUid(string $languageIsoCode, int $pageUid): int
-    {
-        foreach ($this->getLanguages($pageUid) as $language) {
-            if ($language->getTwoLetterIsoCode() === $languageIsoCode) {
-                return $language->getLanguageId();
-            }
-        }
-
-        return 0;
-    }
-
     /**
      * @return SiteLanguage[]
      */
-    private function getLanguages(int $pageUid): array
+    public function getLanguages(int $pageUid): array
     {
         return $this->siteFinder->getSiteByPageId($pageUid)->getLanguages();
+    }
+
+    public function getDefaultLanguage(int $pageUid): SiteLanguage
+    {
+        return $this->siteFinder->getSiteByPageId($pageUid)->getDefaultLanguage();
     }
 }

--- a/Classes/Domain/Import/JsonLD/Parser.php
+++ b/Classes/Domain/Import/JsonLD/Parser.php
@@ -23,6 +23,7 @@ namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\Address;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\GenericFields;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\Media;
@@ -52,12 +53,12 @@ class Parser
         return $jsonLD['@id'];
     }
 
-    public function getTitle(array $jsonLD, string $language = ''): string
+    public function getTitle(array $jsonLD, SiteLanguage $language): string
     {
         return $this->genericFields->getTitle($jsonLD, $language);
     }
 
-    public function getDescription(array $jsonLD, string $language = ''): string
+    public function getDescription(array $jsonLD, SiteLanguage $language): string
     {
         return $this->genericFields->getDescription($jsonLD, $language);
     }
@@ -90,42 +91,5 @@ class Parser
     public function getMedia(array $jsonLD): array
     {
         return $this->media->get($jsonLD);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getLanguages(array $jsonLD): array
-    {
-        if (isset($jsonLD['schema:availableLanguage']) === false) {
-            return [];
-        }
-
-        $languages = $jsonLD['schema:availableLanguage'];
-
-        $languages = array_filter($languages, function (array $language) {
-            return isset($language['@type'])
-                && $language['@type'] === 'thuecat:Language'
-                ;
-        });
-
-        $languages = array_map(function (array $language) {
-            $language = $language['@value'];
-
-            // TODO: Make configurable / easier to extend
-            if ($language === 'thuecat:German') {
-                return 'de';
-            }
-            if ($language === 'thuecat:English') {
-                return 'en';
-            }
-            if ($language === 'thuecat:French') {
-                return 'fr';
-            }
-
-            throw new \Exception('Unsupported language "' . $language . '".', 1612367481);
-        }, $languages);
-
-        return $languages;
     }
 }

--- a/Classes/Domain/Import/JsonLD/Parser/GenericFields.php
+++ b/Classes/Domain/Import/JsonLD/Parser/GenericFields.php
@@ -21,6 +21,8 @@ namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
 class GenericFields
 {
     private LanguageValues $languageValues;
@@ -31,12 +33,12 @@ class GenericFields
         $this->languageValues = $languageValues;
     }
 
-    public function getTitle(array $jsonLD, string $language = ''): string
+    public function getTitle(array $jsonLD, SiteLanguage $language): string
     {
         return $this->languageValues->getValueForLanguage($jsonLD['schema:name'] ?? [], $language);
     }
 
-    public function getDescription(array $jsonLD, string $language = ''): string
+    public function getDescription(array $jsonLD, SiteLanguage $language): string
     {
         return $this->languageValues->getValueForLanguage($jsonLD['schema:description'] ?? [], $language);
     }

--- a/Classes/Domain/Import/JsonLD/Parser/LanguageValues.php
+++ b/Classes/Domain/Import/JsonLD/Parser/LanguageValues.php
@@ -21,15 +21,17 @@ namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
 class LanguageValues
 {
     public function getValueForLanguage(
         array $property,
-        string $language
+        SiteLanguage $language
     ): string {
         if (
-            $this->doesLanguageMatch($property, $language)
-            && isset($property['@value'])
+            isset($property['@value'])
+            && $this->doesLanguageMatch($property, $language)
         ) {
             return $property['@value'];
         }
@@ -48,13 +50,12 @@ class LanguageValues
 
     private function doesLanguageMatch(
         array $property,
-        string $language
+        SiteLanguage $language
     ): bool {
+        $isoCode = $language->getTwoLetterIsoCode();
+
         return isset($property['@language'])
-            && (
-                $property['@language'] === $language
-                || $language === ''
-            )
+            && $property['@language'] === $isoCode
             ;
     }
 }

--- a/Classes/Domain/Import/JsonLD/Parser/Offers.php
+++ b/Classes/Domain/Import/JsonLD/Parser/Offers.php
@@ -21,6 +21,8 @@ namespace WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
  * 02110-1301, USA.
  */
 
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
 class Offers
 {
     private GenericFields $genericFields;
@@ -31,10 +33,17 @@ class Offers
         $this->genericFields = $genericFields;
     }
 
-    public function get(array $jsonLD, string $language): array
+    public function get(array $jsonLD, SiteLanguage $language): array
     {
         $offers = [];
         $jsonLDOffers = $jsonLD['schema:makesOffer'] ?? [];
+
+        if (isset($jsonLDOffers['@id'])) {
+            return [
+                $this->getOffer($jsonLDOffers, $language),
+            ];
+        }
+
         foreach ($jsonLDOffers as $jsonLDOffer) {
             $offer = $this->getOffer($jsonLDOffer, $language);
             if ($offer !== []) {
@@ -45,7 +54,7 @@ class Offers
         return $offers;
     }
 
-    private function getOffer(array $jsonLD, string $language): array
+    private function getOffer(array $jsonLD, SiteLanguage $language): array
     {
         return [
             'title' => $this->genericFields->getTitle($jsonLD, $language),
@@ -54,10 +63,16 @@ class Offers
         ];
     }
 
-    private function getPrices(array $jsonLD, string $language): array
+    private function getPrices(array $jsonLD, SiteLanguage $language): array
     {
         $prices = [];
         $jsonLDPrices = $jsonLD['schema:priceSpecification'] ?? [];
+
+        if (isset($jsonLDPrices['@id'])) {
+            return [
+                $this->getPrice($jsonLDPrices, $language),
+            ];
+        }
 
         foreach ($jsonLDPrices as $jsonLDPrice) {
             $price = $this->getPrice($jsonLDPrice, $language);
@@ -69,7 +84,7 @@ class Offers
         return $prices;
     }
 
-    private function getPrice(array $jsonLD, string $language): array
+    private function getPrice(array $jsonLD, SiteLanguage $language): array
     {
         return [
             'title' => $this->genericFields->getTitle($jsonLD, $language),

--- a/Tests/Unit/Domain/Import/Converter/OrganisationTest.php
+++ b/Tests/Unit/Domain/Import/Converter/OrganisationTest.php
@@ -25,8 +25,10 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\Converter;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\Converter;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\Organisation;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
@@ -46,7 +48,13 @@ class OrganisationTest extends TestCase
     public function instanceCanBeCreated(): void
     {
         $parser = $this->prophesize(Parser::class);
-        $subject = new Organisation($parser->reveal());
+        $language = $this->prophesize(LanguageHandling::class);
+
+        $subject = new Organisation(
+            $parser->reveal(),
+            $language->reveal()
+        );
+
         self::assertInstanceOf(Organisation::class, $subject);
     }
 
@@ -56,7 +64,13 @@ class OrganisationTest extends TestCase
     public function isInstanceOfConverter(): void
     {
         $parser = $this->prophesize(Parser::class);
-        $subject = new Organisation($parser->reveal());
+        $language = $this->prophesize(LanguageHandling::class);
+
+        $subject = new Organisation(
+            $parser->reveal(),
+            $language->reveal()
+        );
+
         self::assertInstanceOf(Converter::class, $subject);
     }
 
@@ -66,7 +80,13 @@ class OrganisationTest extends TestCase
     public function canConvertTouristMarketingCompany(): void
     {
         $parser = $this->prophesize(Parser::class);
-        $subject = new Organisation($parser->reveal());
+        $language = $this->prophesize(LanguageHandling::class);
+
+        $subject = new Organisation(
+            $parser->reveal(),
+            $language->reveal()
+        );
+
         self::assertTrue($subject->canConvert([
             'thuecat:TouristMarketingCompany',
             'schema:Thing',
@@ -89,15 +109,24 @@ class OrganisationTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
+        $language = $this->prophesize(LanguageHandling::class);
+        $language->getDefaultLanguage(10)->willReturn($siteLanguage->reveal());
+
         $parser = $this->prophesize(Parser::class);
         $parser->getId($jsonLD)->willReturn('https://example.com/resources/018132452787-ngbe');
-        $parser->getTitle($jsonLD)->willReturn('Title');
-        $parser->getDescription($jsonLD)->willReturn('Description');
+        $parser->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Title');
+        $parser->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Description');
 
         $configuration = $this->prophesize(ImportConfiguration::class);
         $configuration->getStoragePid()->willReturn(10);
 
-        $subject = new Organisation($parser->reveal());
+        $subject = new Organisation(
+            $parser->reveal(),
+            $language->reveal()
+        );
+
         $entities = $subject->convert($jsonLD, $configuration->reveal());
 
         self::assertInstanceOf(EntityCollection::class, $entities);

--- a/Tests/Unit/Domain/Import/Converter/TouristInformationTest.php
+++ b/Tests/Unit/Domain/Import/Converter/TouristInformationTest.php
@@ -25,8 +25,10 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\Converter;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\Converter;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\TouristInformation;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
@@ -50,11 +52,13 @@ class TouristInformationTest extends TestCase
     public function instanceCanBeCreated(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
         $townRepository = $this->prophesize(TownRepository::class);
 
         $subject = new TouristInformation(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal(),
             $townRepository->reveal()
         );
@@ -67,11 +71,13 @@ class TouristInformationTest extends TestCase
     public function isInstanceOfConverter(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
         $townRepository = $this->prophesize(TownRepository::class);
 
         $subject = new TouristInformation(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal(),
             $townRepository->reveal()
         );
@@ -84,11 +90,13 @@ class TouristInformationTest extends TestCase
     public function canConvertTouristMarketingCompany(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
         $townRepository = $this->prophesize(TownRepository::class);
 
         $subject = new TouristInformation(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal(),
             $townRepository->reveal()
         );
@@ -125,6 +133,11 @@ class TouristInformationTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
+        $language = $this->prophesize(LanguageHandling::class);
+        $language->getDefaultLanguage(10)->willReturn($siteLanguage);
+
         $parser = $this->prophesize(Parser::class);
         $parser->getManagerId($jsonLD)->willReturn('https://example.com/resources/018132452787-xxxx');
         $parser->getContainedInPlaceIds($jsonLD)->willReturn([
@@ -132,8 +145,8 @@ class TouristInformationTest extends TestCase
             'https://example.com/resources/573211638937-gmqb',
         ]);
         $parser->getId($jsonLD)->willReturn('https://example.com/resources/018132452787-ngbe');
-        $parser->getTitle($jsonLD)->willReturn('Title');
-        $parser->getDescription($jsonLD)->willReturn('Description');
+        $parser->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Title');
+        $parser->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Description');
 
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
         $organisationRepository->findOneByRemoteId('https://example.com/resources/018132452787-xxxx')
@@ -150,6 +163,7 @@ class TouristInformationTest extends TestCase
 
         $subject = new TouristInformation(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal(),
             $townRepository->reveal()
         );
@@ -199,6 +213,11 @@ class TouristInformationTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
+        $language = $this->prophesize(LanguageHandling::class);
+        $language->getDefaultLanguage(10)->willReturn($siteLanguage);
+
         $parser = $this->prophesize(Parser::class);
         $parser->getManagerId($jsonLD)->willReturn('https://example.com/resources/018132452787-xxxx');
         $parser->getContainedInPlaceIds($jsonLD)->willReturn([
@@ -206,8 +225,8 @@ class TouristInformationTest extends TestCase
             'https://example.com/resources/573211638937-gmqb',
         ]);
         $parser->getId($jsonLD)->willReturn('https://example.com/resources/018132452787-ngbe');
-        $parser->getTitle($jsonLD)->willReturn('Title');
-        $parser->getDescription($jsonLD)->willReturn('Description');
+        $parser->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Title');
+        $parser->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Description');
 
         $organisation = $this->prophesize(Organisation::class);
         $organisation->getUid()->willReturn(10);
@@ -228,6 +247,7 @@ class TouristInformationTest extends TestCase
 
         $subject = new TouristInformation(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal(),
             $townRepository->reveal()
         );

--- a/Tests/Unit/Domain/Import/Converter/TownTest.php
+++ b/Tests/Unit/Domain/Import/Converter/TownTest.php
@@ -25,8 +25,10 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\Converter;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\Converter;
 use WerkraumMedia\ThueCat\Domain\Import\Converter\Town;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\LanguageHandling;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\Model\EntityCollection;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
@@ -48,10 +50,12 @@ class TownTest extends TestCase
     public function instanceCanBeCreated(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
 
         $subject = new Town(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal()
         );
         self::assertInstanceOf(Town::class, $subject);
@@ -63,10 +67,12 @@ class TownTest extends TestCase
     public function isInstanceOfConverter(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
 
         $subject = new Town(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal()
         );
         self::assertInstanceOf(Converter::class, $subject);
@@ -78,10 +84,12 @@ class TownTest extends TestCase
     public function canConvertTouristMarketingCompany(): void
     {
         $parser = $this->prophesize(Parser::class);
+        $language = $this->prophesize(LanguageHandling::class);
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
 
         $subject = new Town(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal()
         );
         self::assertTrue($subject->canConvert([
@@ -107,11 +115,16 @@ class TownTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
+        $language = $this->prophesize(LanguageHandling::class);
+        $language->getDefaultLanguage(10)->willReturn($siteLanguage->reveal());
+
         $parser = $this->prophesize(Parser::class);
         $parser->getManagerId($jsonLD)->willReturn('https://example.com/resources/018132452787-xxxx');
         $parser->getId($jsonLD)->willReturn('https://example.com/resources/018132452787-ngbe');
-        $parser->getTitle($jsonLD)->willReturn('Title');
-        $parser->getDescription($jsonLD)->willReturn('Description');
+        $parser->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Title');
+        $parser->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Description');
 
         $organisationRepository = $this->prophesize(OrganisationRepository::class);
         $organisationRepository->findOneByRemoteId('https://example.com/resources/018132452787-xxxx')->willReturn(null);
@@ -121,6 +134,7 @@ class TownTest extends TestCase
 
         $subject = new Town(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal()
         );
         $entities = $subject->convert($jsonLD, $configuration->reveal());
@@ -158,11 +172,16 @@ class TownTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
+        $language = $this->prophesize(LanguageHandling::class);
+        $language->getDefaultLanguage(10)->willReturn($siteLanguage->reveal());
+
         $parser = $this->prophesize(Parser::class);
         $parser->getManagerId($jsonLD)->willReturn('https://example.com/resources/018132452787-xxxx');
         $parser->getId($jsonLD)->willReturn('https://example.com/resources/018132452787-ngbe');
-        $parser->getTitle($jsonLD)->willReturn('Title');
-        $parser->getDescription($jsonLD)->willReturn('Description');
+        $parser->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Title');
+        $parser->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Description');
 
         $organisation = $this->prophesize(Organisation::class);
         $organisation->getUid()->willReturn(10);
@@ -174,6 +193,7 @@ class TownTest extends TestCase
 
         $subject = new Town(
             $parser->reveal(),
+            $language->reveal(),
             $organisationRepository->reveal()
         );
         $entities = $subject->convert($jsonLD, $configuration->reveal());

--- a/Tests/Unit/Domain/Import/Importer/LanguageHandlingTest.php
+++ b/Tests/Unit/Domain/Import/Importer/LanguageHandlingTest.php
@@ -52,53 +52,7 @@ class LanguageHandlingTest extends TestCase
     /**
      * @test
      */
-    public function allowsToCheckForUnkownLanguage(): void
-    {
-        $language = $this->prophesize(SiteLanguage::class);
-        $language->getTwoLetterIsoCode()->willReturn('en');
-
-        $site = $this->prophesize(Site::class);
-        $site->getLanguages()->willReturn([$language->reveal()]);
-
-        $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(10)->willReturn($site->reveal());
-
-        $subject = new LanguageHandling(
-            $siteFinder->reveal()
-        );
-
-        $result = $subject->isUnknown('de', 10);
-
-        self::assertTrue($result);
-    }
-
-    /**
-     * @test
-     */
-    public function allowsToCheckForKnownLanguage(): void
-    {
-        $language = $this->prophesize(SiteLanguage::class);
-        $language->getTwoLetterIsoCode()->willReturn('de');
-
-        $site = $this->prophesize(Site::class);
-        $site->getLanguages()->willReturn([$language->reveal()]);
-
-        $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(10)->willReturn($site->reveal());
-
-        $subject = new LanguageHandling(
-            $siteFinder->reveal()
-        );
-
-        $result = $subject->isUnknown('de', 10);
-
-        self::assertFalse($result);
-    }
-
-    /**
-     * @test
-     */
-    public function providesSystemLanguageUidForLanguage(): void
+    public function returnsAllLanguagesForGivenPageUid(): void
     {
         $language = $this->prophesize(SiteLanguage::class);
         $language->getTwoLetterIsoCode()->willReturn('de');
@@ -114,21 +68,24 @@ class LanguageHandlingTest extends TestCase
             $siteFinder->reveal()
         );
 
-        $result = $subject->getSystemUid('de', 10);
+        $result = $subject->getLanguages(10);
 
-        self::assertSame(2, $result);
+        self::assertCount(1, $result);
+        self::assertSame(2, $result[0]->getLanguageId());
+        self::assertSame('de', $result[0]->getTwoLetterIsoCode());
     }
 
     /**
      * @test
      */
-    public function providesZeroAsFallbackSystemLanguageUidForUnkownLanguage(): void
+    public function returnsDefaultLanguageForGivenPageUid(): void
     {
         $language = $this->prophesize(SiteLanguage::class);
-        $language->getTwoLetterIsoCode()->willReturn('fr');
+        $language->getTwoLetterIsoCode()->willReturn('de');
+        $language->getLanguageId()->willReturn(2);
 
         $site = $this->prophesize(Site::class);
-        $site->getLanguages()->willReturn([$language->reveal()]);
+        $site->getDefaultLanguage()->willReturn($language->reveal());
 
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(10)->willReturn($site->reveal());
@@ -137,8 +94,10 @@ class LanguageHandlingTest extends TestCase
             $siteFinder->reveal()
         );
 
-        $result = $subject->getSystemUid('de', 10);
+        $result = $subject->getDefaultLanguage(10);
 
-        self::assertSame(0, $result);
+        self::assertInstanceOf(SiteLanguage::class, $result);
+        self::assertSame(2, $result->getLanguageId());
+        self::assertSame('de', $result->getTwoLetterIsoCode());
     }
 }

--- a/Tests/Unit/Domain/Import/JsonLD/Parser/GenericFieldsTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/Parser/GenericFieldsTest.php
@@ -23,6 +23,7 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD\Parser;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\GenericFields;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\LanguageValues;
 
@@ -52,10 +53,12 @@ class GenericFieldsTest extends TestCase
      */
     public function returnsTitle(): void
     {
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
         $languageValues = $this->prophesize(LanguageValues::class);
         $languageValues->getValueForLanguage([
             '@value' => 'DE Title',
-        ], 'de')->willReturn('DE Title');
+        ], $siteLanguage->reveal())->willReturn('DE Title');
 
         $subject = new GenericFields(
             $languageValues->reveal()
@@ -65,7 +68,7 @@ class GenericFieldsTest extends TestCase
             'schema:name' => [
                 '@value' => 'DE Title',
             ],
-        ], 'de');
+        ], $siteLanguage->reveal());
 
         self::assertSame('DE Title', $result);
     }
@@ -75,10 +78,12 @@ class GenericFieldsTest extends TestCase
      */
     public function returnsDescription(): void
     {
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
         $languageValues = $this->prophesize(LanguageValues::class);
         $languageValues->getValueForLanguage([
             '@value' => 'DE Description',
-        ], 'de')->willReturn('DE Description');
+        ], $siteLanguage->reveal())->willReturn('DE Description');
 
         $subject = new GenericFields(
             $languageValues->reveal()
@@ -88,7 +93,7 @@ class GenericFieldsTest extends TestCase
             'schema:description' => [
                 '@value' => 'DE Description',
             ],
-        ], 'de');
+        ], $siteLanguage->reveal());
 
         self::assertSame('DE Description', $result);
     }

--- a/Tests/Unit/Domain/Import/JsonLD/Parser/LanguageValuesTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/Parser/LanguageValuesTest.php
@@ -22,6 +22,8 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD\Parser;
  */
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\LanguageValues;
 
 /**
@@ -29,6 +31,8 @@ use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\LanguageValues;
  */
 class LanguageValuesTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -46,10 +50,13 @@ class LanguageValuesTest extends TestCase
      */
     public function returnsValue(array $jsonLD, string $language, string $expected): void
     {
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+        $siteLanguage->getTwoLetterIsoCode()->willReturn($language);
+
         $subject = new LanguageValues(
         );
 
-        $result = $subject->getValueForLanguage($jsonLD, $language);
+        $result = $subject->getValueForLanguage($jsonLD, $siteLanguage->reveal());
 
         self::assertSame($expected, $result);
     }
@@ -69,20 +76,6 @@ class LanguageValuesTest extends TestCase
                     ],
                 ],
                 'language' => 'de',
-                'expected' => 'DE value',
-            ],
-            'has multiple lanugages, no language specified' => [
-                'jsonLD' => [
-                    [
-                        '@language' => 'de',
-                        '@value' => 'DE value',
-                    ],
-                    [
-                        '@language' => 'fr',
-                        '@value' => 'FR value',
-                    ],
-                ],
-                'language' => '',
                 'expected' => 'DE value',
             ],
             'has multiple languages, none matches' => [
@@ -126,14 +119,6 @@ class LanguageValuesTest extends TestCase
                 ],
                 'language' => 'en',
                 'expected' => '',
-            ],
-            'has single language, no language specified' => [
-                'jsonLD' => [
-                    '@language' => 'de',
-                    '@value' => 'DE value',
-                ],
-                'language' => '',
-                'expected' => 'DE value',
             ],
             'has single language, missing @language key' => [
                 'jsonLD' => [

--- a/Tests/Unit/Domain/Import/JsonLD/Parser/OffersTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/Parser/OffersTest.php
@@ -23,6 +23,7 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD\Parser;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\GenericFields;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\Offers;
 
@@ -52,13 +53,14 @@ class OffersTest extends TestCase
      */
     public function returnsEmptyArrayIfNoOfferExists(): void
     {
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
         $genericFields = $this->prophesize(GenericFields::class);
 
         $subject = new Offers(
             $genericFields->reveal()
         );
 
-        $result = $subject->get([], '');
+        $result = $subject->get([], $siteLanguage->reveal());
 
         self::assertSame([], $result);
     }
@@ -66,7 +68,7 @@ class OffersTest extends TestCase
     /**
      * @test
      */
-    public function returnsSingleOfferWithSinglePrice(): void
+    public function returnsMultipleOfferWithMultiplePrices(): void
     {
         $jsonLD = [
             'schema:makesOffer' => [
@@ -255,53 +257,66 @@ class OffersTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
         $genericFields = $this->prophesize(GenericFields::class);
 
         // Offer 1
-        $genericFields->getTitle($jsonLD['schema:makesOffer'][0], 'de')->willReturn('Führungen');
-        $genericFields->getDescription($jsonLD['schema:makesOffer'][0], 'de')->willReturn('Immer samstags, um 11:15 Uhr findet eine öffentliche Führung durch das Museum statt. Dauer etwa 90 Minuten');
+        $genericFields->getTitle(
+            $jsonLD['schema:makesOffer'][0],
+            $siteLanguage->reveal()
+        )->willReturn('Führungen');
+        $genericFields->getDescription(
+            $jsonLD['schema:makesOffer'][0],
+            $siteLanguage->reveal()
+        )->willReturn('Immer samstags, um 11:15 Uhr findet eine öffentliche Führung durch das Museum statt. Dauer etwa 90 Minuten');
         $genericFields->getTitle(
             $jsonLD['schema:makesOffer'][0]['schema:priceSpecification'][0],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('Erwachsene');
         $genericFields->getDescription(
             $jsonLD['schema:makesOffer'][0]['schema:priceSpecification'][0],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('');
         $genericFields->getTitle(
             $jsonLD['schema:makesOffer'][0]['schema:priceSpecification'][1],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('Ermäßigt');
         $genericFields->getDescription(
             $jsonLD['schema:makesOffer'][0]['schema:priceSpecification'][1],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('als ermäßigt gelten schulpflichtige Kinder, Auszubildende, Studierende, Rentner/-innen, Menschen mit Behinderungen, Inhaber Sozialausweis der Landeshauptstadt Erfurt');
 
         // Offer2
-        $genericFields->getTitle($jsonLD['schema:makesOffer'][1], 'de')->willReturn('Eintritt');
-        $genericFields->getDescription($jsonLD['schema:makesOffer'][1], 'de')->willReturn("Schulklassen und Kitagruppen im Rahmen des Unterrichts: Eintritt frei\nAn jedem ersten Dienstag im Monat: Eintritt frei");
+        $genericFields->getTitle(
+            $jsonLD['schema:makesOffer'][1],
+            $siteLanguage->reveal()
+        )->willReturn('Eintritt');
+        $genericFields->getDescription(
+            $jsonLD['schema:makesOffer'][1],
+            $siteLanguage->reveal()
+        )->willReturn("Schulklassen und Kitagruppen im Rahmen des Unterrichts: Eintritt frei\nAn jedem ersten Dienstag im Monat: Eintritt frei");
         $genericFields->getTitle(
             $jsonLD['schema:makesOffer'][1]['schema:priceSpecification'][0],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('Ermäßigt');
         $genericFields->getDescription(
             $jsonLD['schema:makesOffer'][1]['schema:priceSpecification'][0],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('als ermäßigt gelten schulpflichtige Kinder, Auszubildende, Studierende, Rentner/-innen, Menschen mit Behinderungen, Inhaber Sozialausweis der Landeshauptstadt Erfurt');
         $genericFields->getTitle(
             $jsonLD['schema:makesOffer'][1]['schema:priceSpecification'][1],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('Familienkarte');
         $genericFields->getDescription(
             $jsonLD['schema:makesOffer'][1]['schema:priceSpecification'][1],
-            'de'
+            $siteLanguage->reveal()
         )->willReturn('');
 
         $subject = new Offers(
             $genericFields->reveal()
         );
 
-        $result = $subject->get($jsonLD, 'de');
+        $result = $subject->get($jsonLD, $siteLanguage->reveal());
 
         self::assertSame([
             [
@@ -341,6 +356,113 @@ class OffersTest extends TestCase
                         'price' => 17.0,
                         'currency' => 'EUR',
                         'rule' => 'PerGroup',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsSingleOfferWithSinglePrice(): void
+    {
+        $jsonLD = [
+            'schema:makesOffer' => [
+                '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b5',
+                '@type' => [
+                    0 => 'schema:Intangible',
+                    1 => 'schema:Thing',
+                    2 => 'schema:Offer',
+                ],
+                'rdfs:label' => [
+                    '@language' => 'de',
+                    '@value' => 'Führungen',
+                ],
+                'schema:description' => [
+                    '@language' => 'de',
+                    '@value' => 'Immer samstags, um 11:15 Uhr findet eine öffentliche Führung durch das Museum statt. Dauer etwa 90 Minuten',
+                ],
+                'schema:name' => [
+                    '@language' => 'de',
+                    '@value' => 'Führungen',
+                ],
+                'schema:offeredBy' => [
+                    '@id' => 'https://thuecat.org/resources/165868194223-zmqf',
+                ],
+                'schema:priceSpecification' => [
+                    '@id' => 'genid-28b33237f71b41e3ad54a99e1da769b9-b6',
+                    '@type' => [
+                        0 => 'schema:Intangible',
+                        1 => 'schema:StructuredValue',
+                        2 => 'schema:PriceSpecification',
+                        3 => 'schema:Thing',
+                    ],
+                    'rdfs:label' => [
+                        '@language' => 'de',
+                        '@value' => 'Erwachsene',
+                    ],
+                    'schema:name' => [
+                        '@language' => 'de',
+                        '@value' => 'Erwachsene',
+                    ],
+                    'schema:price' => [
+                        '@type' => 'schema:Number',
+                        '@value' => '8',
+                    ],
+                    'schema:priceCurrency' => [
+                        '@type' => 'thuecat:Currency',
+                        '@value' => 'thuecat:EUR',
+                    ],
+                    'thuecat:calculationRule' => [
+                        '@type' => 'thuecat:CalculationRule',
+                        '@value' => 'thuecat:PerPerson',
+                    ],
+                ],
+                'thuecat:offerType' => [
+                    '@type' => 'thuecat:OfferType',
+                    '@value' => 'thuecat:GuidedTourOffer',
+                ],
+            ],
+        ];
+
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+        $genericFields = $this->prophesize(GenericFields::class);
+
+        $genericFields->getTitle(
+            $jsonLD['schema:makesOffer'],
+            $siteLanguage->reveal()
+        )->willReturn('Führungen');
+        $genericFields->getDescription(
+            $jsonLD['schema:makesOffer'],
+            $siteLanguage->reveal()
+        )->willReturn('Immer samstags, um 11:15 Uhr findet eine öffentliche Führung durch das Museum statt. Dauer etwa 90 Minuten');
+        $genericFields->getTitle(
+            $jsonLD['schema:makesOffer']['schema:priceSpecification'],
+            $siteLanguage->reveal()
+        )->willReturn('Erwachsene');
+        $genericFields->getDescription(
+            $jsonLD['schema:makesOffer']['schema:priceSpecification'],
+            $siteLanguage->reveal()
+        )->willReturn('');
+
+        $subject = new Offers(
+            $genericFields->reveal()
+        );
+
+        $result = $subject->get($jsonLD, $siteLanguage->reveal());
+
+        self::assertSame([
+            [
+                'title' => 'Führungen',
+                'description' => 'Immer samstags, um 11:15 Uhr findet eine öffentliche Führung durch das Museum statt. Dauer etwa 90 Minuten',
+                'prices' => [
+                    [
+                        'title' => 'Erwachsene',
+                        'description' => '',
+                        'price' => 8.0,
+                        'currency' => 'EUR',
+                        'rule' => 'PerPerson',
                     ],
                 ],
             ],

--- a/Tests/Unit/Domain/Import/JsonLD/ParserTest.php
+++ b/Tests/Unit/Domain/Import/JsonLD/ParserTest.php
@@ -25,6 +25,7 @@ namespace WerkraumMedia\ThueCat\Tests\Unit\Domain\Import\JsonLD;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\Address;
 use WerkraumMedia\ThueCat\Domain\Import\JsonLD\Parser\GenericFields;
@@ -94,8 +95,10 @@ class ParserTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
         $genericFields = $this->prophesize(GenericFields::class);
-        $genericFields->getTitle($jsonLD, 'de')->willReturn('Erfurt');
+        $genericFields->getTitle($jsonLD, $siteLanguage->reveal())->willReturn('Erfurt');
 
         $openingHours = $this->prophesize(OpeningHours::class);
         $address = $this->prophesize(Address::class);
@@ -108,7 +111,7 @@ class ParserTest extends TestCase
             $media->reveal()
         );
 
-        $result = $subject->getTitle($jsonLD, 'de');
+        $result = $subject->getTitle($jsonLD, $siteLanguage->reveal());
 
         self::assertSame('Erfurt', $result);
     }
@@ -125,8 +128,10 @@ class ParserTest extends TestCase
             ],
         ];
 
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
+
         $genericFields = $this->prophesize(GenericFields::class);
-        $genericFields->getDescription($jsonLD, 'de')->willReturn('Erfurt');
+        $genericFields->getDescription($jsonLD, $siteLanguage->reveal())->willReturn('Erfurt');
 
         $openingHours = $this->prophesize(OpeningHours::class);
         $address = $this->prophesize(Address::class);
@@ -139,7 +144,7 @@ class ParserTest extends TestCase
             $media->reveal()
         );
 
-        $result = $subject->getDescription($jsonLD, 'de');
+        $result = $subject->getDescription($jsonLD, $siteLanguage->reveal());
 
         self::assertSame('Erfurt', $result);
     }
@@ -204,97 +209,6 @@ class ParserTest extends TestCase
             'https://thuecat.org/resources/476888881990-xpwq',
             'https://thuecat.org/resources/573211638937-gmqb',
         ], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function returnsLanguages(): void
-    {
-        $genericFields = $this->prophesize(GenericFields::class);
-        $openingHours = $this->prophesize(OpeningHours::class);
-        $address = $this->prophesize(Address::class);
-        $media = $this->prophesize(Media::class);
-
-        $subject = new Parser(
-            $genericFields->reveal(),
-            $openingHours->reveal(),
-            $address->reveal(),
-            $media->reveal()
-        );
-
-        $result = $subject->getLanguages([
-            'schema:availableLanguage' => [
-                0 => [
-                    '@type' => 'thuecat:Language',
-                    '@value' => 'thuecat:German',
-                ],
-                1 => [
-                    '@type' => 'thuecat:Language',
-                    '@value' => 'thuecat:English',
-                ],
-                2 => [
-                    '@type' => 'thuecat:Language',
-                    '@value' => 'thuecat:French',
-                ],
-            ],
-        ]);
-
-        self::assertSame([
-            'de',
-            'en',
-            'fr',
-        ], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function throwsExceptionOnUnkownLanguage(): void
-    {
-        $genericFields = $this->prophesize(GenericFields::class);
-        $openingHours = $this->prophesize(OpeningHours::class);
-        $address = $this->prophesize(Address::class);
-        $media = $this->prophesize(Media::class);
-
-        $subject = new Parser(
-            $genericFields->reveal(),
-            $openingHours->reveal(),
-            $address->reveal(),
-            $media->reveal()
-        );
-
-        $this->expectExceptionCode(1612367481);
-        $result = $subject->getLanguages([
-            'schema:availableLanguage' => [
-                0 => [
-                    '@type' => 'thuecat:Language',
-                    '@value' => 'thuecat:Unkown',
-                ],
-            ],
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function returnsNoLanguagesIfInfoIsMissing(): void
-    {
-        $genericFields = $this->prophesize(GenericFields::class);
-        $openingHours = $this->prophesize(OpeningHours::class);
-        $address = $this->prophesize(Address::class);
-        $media = $this->prophesize(Media::class);
-
-        $subject = new Parser(
-            $genericFields->reveal(),
-            $openingHours->reveal(),
-            $address->reveal(),
-            $media->reveal()
-        );
-
-        $result = $subject->getLanguages([]);
-
-        self::assertSame([], $result);
     }
 
     /**


### PR DESCRIPTION
Sorry for fixing two things in one commit.

First fixed bug is single offer and / or single price.
Those lead to exception / fatal error and are now handled.

Second fixed bug is wrong multi language handling.
Instead of using supported languages from entity (which does not exist
and was miss interpreted) we use configured system languages.
Each record is inserted with default language.
Also tourist attractions are inserted for all other languages.
They are only inserted if they have a title for that language.