### PR TITLE
Allow editor to create and edit import configuration

### DIFF
--- a/Configuration/TCA/tx_thuecat_import_configuration.php
+++ b/Configuration/TCA/tx_thuecat_import_configuration.php
@@ -20,7 +20,7 @@ return (static function (string $extensionKey, string $tableName) {
                 'disabled' => 'disable',
             ],
             'searchFields' => 'title',
-            'rootLevel' => 1,
+            'rootLevel' => -1,
         ],
         'columns' => [
             'title' => [

--- a/Configuration/TypoScript/Default/Setup.typoscript
+++ b/Configuration/TypoScript/Default/Setup.typoscript
@@ -1,5 +1,10 @@
 module {
     tx_thuecat {
+        settings {
+            newRecordPid {
+                tx_thuecat_import_configuration = 0
+            }
+        }
         view {
             templateRootPaths {
                 0 = EXT:thuecat/Resources/Private/Templates/

--- a/Resources/Private/Templates/Backend/Overview/Index.html
+++ b/Resources/Private/Templates/Backend/Overview/Index.html
@@ -11,6 +11,7 @@
         {f:translate(id: 'module.importConfigurations.headline')}
         <f:link.newRecord
             table="tx_thuecat_import_configuration"
+            pid="{settings.newRecordPid.tx_thuecat_import_configuration}"
             title="{f:translate(id: 'module.importConfigurations.actions.new')}"
         >
             {f:icon(identifier: 'actions-document-add')}
@@ -28,7 +29,7 @@
                 {f:translate(
                     id: 'module.importConfigurations.missing.text',
                     arguments: {
-                        0: "{f:uri.newRecord(table: 'tx_thuecat_import_configuration')}"
+                        0: "{f:uri.newRecord(table: 'tx_thuecat_import_configuration', pid: settings.newRecordPid.tx_thuecat_import_configuration)}"
                     }
                 ) -> f:format.raw()}
             </f:be.infobox>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,3 +3,9 @@
 defined('TYPO3') or die();
 
 \WerkraumMedia\ThueCat\Extension::registerConfig();
+
+(static function (string $extensionKey) {
+    TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
+        '@import "EXT:' . $extensionKey . '/Configuration/TypoScript/Default/Setup.typoscript"'
+    );
+})(\WerkraumMedia\ThueCat\Extension::EXTENSION_KEY);


### PR DESCRIPTION
Import Configuration can now be stored on folders, beside the site root.
That way editors can create and edit records.
The default storage pid for new records can be defined via TypoScript.

Resolves: #24