### PR TITLE
Sort offer prices by title

### DIFF
--- a/Classes/Domain/Model/Frontend/Offer.php
+++ b/Classes/Domain/Model/Frontend/Offer.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace WerkraumMedia\ThueCat\Domain\Model\Frontend;
 
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
 class Offer
 {
     /**
@@ -56,7 +58,8 @@ class Offer
     public static function createFromArray(array $rawData)
     {
         $prices = [];
-        foreach ($rawData['prices'] as $price) {
+
+        foreach (ArrayUtility::sortArraysByKey($rawData['prices'], 'title') as $price) {
             $prices[] = Price::createFromArray($price);
         }
 

--- a/Tests/Functional/Fixtures/Frontend/TouristAttractionWithPrices.xml
+++ b/Tests/Functional/Fixtures/Frontend/TouristAttractionWithPrices.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_thuecat_tourist_attraction>
+        <uid>1</uid>
+        <pid>3</pid>
+        <title>Attraktion mit Preisen</title>
+        <offers>[{"prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"},{"currency":"EUR","description":"","price":8,"rule":"PerPerson","title":"Erwachsene"},{"currency":"EUR","description":"","price":5,"rule":"PerPerson","title":"Familienkarte B"},{"currency":"EUR","description":"","price":5,"rule":"PerPerson","title":"Familienkarte A"}],"description":"","title":"Führungen"}]</offers>
+    </tx_thuecat_tourist_attraction>
+</dataset>
+

--- a/Tests/Functional/FrontendTest.php
+++ b/Tests/Functional/FrontendTest.php
@@ -89,4 +89,37 @@ class FrontendTest extends FunctionalTestCase
         self::assertStringContainsString('8,00 EUR', (string)$result->getBody());
         self::assertStringContainsString('pro Person', (string)$result->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function pricesAreSorted(): void
+    {
+        $this->importDataSet('EXT:thuecat/Tests/Functional/Fixtures/Frontend/TouristAttractionWithPrices.xml');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(2);
+
+        $result = $this->executeFrontendRequest($request);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        self::assertStringContainsString('Attraktion mit Preisen', (string)$result->getBody());
+
+        self::assertLessThan(
+            mb_strpos((string)$result->getBody(), 'Familienkarte A'),
+            mb_strpos((string)$result->getBody(), 'Erwachsene'),
+            '"Familienkarte A" is rendered before "Erwachsene"'
+        );
+        self::assertLessThan(
+            mb_strpos((string)$result->getBody(), 'Familienkarte B'),
+            mb_strpos((string)$result->getBody(), 'Familienkarte A'),
+            '"Familienkarte B" is rendered before "Familienkarte A"'
+        );
+        self::assertLessThan(
+            mb_strpos((string)$result->getBody(), 'Schulklassen'),
+            mb_strpos((string)$result->getBody(), 'Familienkarte B'),
+            '"Schulklassen" is rendered before "Familienkarte B"'
+        );
+    }
 }


### PR DESCRIPTION
ThüCAT doesn't provide the editorial order of prices.
Therefore our frontend now renders them based on title in alphabetical
order.