### PR TITLE
Sort offers by type

### DIFF
--- a/Classes/Domain/Model/Frontend/Offers.php
+++ b/Classes/Domain/Model/Frontend/Offers.php
@@ -48,10 +48,14 @@ class Offers implements TypeInterface, \Iterator, \Countable
     public function __construct(string $serialized)
     {
         $this->serialized = $serialized;
-        $this->array = array_map(
-            [Offer::class, 'createFromArray'],
-            json_decode($serialized, true)
-        );
+        $array = json_decode($serialized, true);
+        if (is_array($array)) {
+            $array = array_map([Offer::class, 'createFromArray'], $array);
+            usort($array, function (Offer $offerA, Offer $offerB) {
+                return $offerA->getType() <=> $offerB->getType();
+            });
+            $this->array = $array;
+        }
     }
 
     public function __toString(): string

--- a/Tests/Functional/Fixtures/Frontend/TouristAttractionWithOfferTypes.xml
+++ b/Tests/Functional/Fixtures/Frontend/TouristAttractionWithOfferTypes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_thuecat_tourist_attraction>
+        <uid>1</uid>
+        <pid>3</pid>
+        <title>Attraktion mit Angebotstypen</title>
+        <offers>[{"description":"","prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"}],"title":"Führungen","type":"GuidedTourOffer"},{"description":"","prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"}],"title":"Verkostung","type":"Tasting"},{"description":"","prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"}],"title":"Eintritt 1","type":"EntryOffer"},{"description":"","prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"}],"title":"Eintritt 2","type":"EntryOffer"},{"description":"","prices":[{"currency":"EUR","description":"","price":8,"rule":"PerGroup","title":"Schulklassen"}],"title":"Parkgebühr","type":"ParkingFee"}]</offers>
+    </tx_thuecat_tourist_attraction>
+</dataset>
+

--- a/Tests/Functional/FrontendTest.php
+++ b/Tests/Functional/FrontendTest.php
@@ -373,20 +373,58 @@ class FrontendTest extends FunctionalTestCase
 
         self::assertStringContainsString('Attraktion mit Preisen', (string)$result->getBody());
 
-        self::assertLessThan(
-            mb_strpos((string)$result->getBody(), 'Familienkarte A'),
+        self::assertGreaterThan(
             mb_strpos((string)$result->getBody(), 'Erwachsene'),
-            '"Familienkarte A" is rendered before "Erwachsene"'
-        );
-        self::assertLessThan(
-            mb_strpos((string)$result->getBody(), 'Familienkarte B'),
             mb_strpos((string)$result->getBody(), 'Familienkarte A'),
-            '"Familienkarte B" is rendered before "Familienkarte A"'
+            '"Erwachsene" is not rendered before "Familienkarte A"'
         );
-        self::assertLessThan(
-            mb_strpos((string)$result->getBody(), 'Schulklassen'),
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Familienkarte A'),
             mb_strpos((string)$result->getBody(), 'Familienkarte B'),
-            '"Schulklassen" is rendered before "Familienkarte B"'
+            '"Familienkarte A" is not rendered before "Familienkarte B"'
+        );
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Familienkarte B'),
+            mb_strpos((string)$result->getBody(), 'Schulklassen'),
+            '"Familienkarte B" is not rendered before "Schulklassen"'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function offersAreSortedByType(): void
+    {
+        $this->importDataSet('EXT:thuecat/Tests/Functional/Fixtures/Frontend/TouristAttractionWithOfferTypes.xml');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(2);
+
+        $result = $this->executeFrontendRequest($request);
+
+        self::assertSame(200, $result->getStatusCode());
+
+        self::assertStringContainsString('Attraktion mit Angebotstypen', (string)$result->getBody());
+
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Eintritt 1'),
+            mb_strpos((string)$result->getBody(), 'Eintritt 2'),
+            '"Eintritt 1" is not rendered before "Eintritt 2"'
+        );
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Eintritt 2'),
+            mb_strpos((string)$result->getBody(), 'Führungen'),
+            '"Eintritt 2" is not rendered before "Führungen"'
+        );
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Führungen'),
+            mb_strpos((string)$result->getBody(), 'Parkgebühr'),
+            '"Führungen" is not rendered before "Parkgebühr"'
+        );
+        self::assertGreaterThan(
+            mb_strpos((string)$result->getBody(), 'Parkgebühr'),
+            mb_strpos((string)$result->getBody(), 'Verkostung'),
+            '"Parkgebühr" is not rendered before "Verkostung"'
         );
     }
 }


### PR DESCRIPTION
That ensures grouped output of related offers.
Offers are not sorted in any way and might end up in entry, parking,
entry, etc. Sorting ensures all of same type are rendered one after the
other, entry, entry, parking.

Sorting is done by alphabet on the technical enum value.