### PR TITLE
Remove deprecated usage of StringUtility::endsWith()

### DIFF
--- a/Classes/Domain/Import/Import.php
+++ b/Classes/Domain/Import/Import.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace WerkraumMedia\ThueCat\Domain\Import;
 
-use TYPO3\CMS\Core\Utility\StringUtility;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration as Typo3ImportConfiguration;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLog;
 
@@ -105,7 +104,7 @@ class Import
     {
         // Tours are not supported yet.
         // So skip them here to save time.
-        if (StringUtility::endsWith($remoteId, '-oatour')) {
+        if (str_ends_with($remoteId, '-oatour')) {
             return true;
         }
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -19,4 +19,5 @@ Table of Contents
    Installation
    Configuration
    Changelog
+   Maintenance
    Sitemap

--- a/Documentation/Maintenance.rst
+++ b/Documentation/Maintenance.rst
@@ -1,0 +1,17 @@
+.. _maintenance:
+
+Maintenance
+===========
+
+List of changes that need to be done for maintenance reasons.
+Those affect the extension itself, not users of the extension.
+
+E.g. changes once we drop a certain TYPO3 version.
+We might have new code backported for compatibility in older TYPO3 versions.
+Those changes are documented so we know what to do once we drop an older version.
+
+.. toctree::
+   :glob:
+   :reversed:
+
+   Maintenance/PHP/*

--- a/Documentation/Maintenance/PHP/7.4.rst
+++ b/Documentation/Maintenance/PHP/7.4.rst
@@ -1,0 +1,15 @@
+PHP 7.4
+=======
+
+Changes that should happen once we drop PHP 7.4.
+
+Remove ``symfony/polyfill-php80`` dependency
+--------------------------------------------
+
+We use PHP 8.0 functions within our code base (to not add legacy code and deprecations).
+
+One example is :file:`Classes/Domain/Import/Import.php` where we use ``str_ends_with()``.
+We therefore added ``symfony/polyfill-php80`` as composer package to already make use of those functions.
+
+We can drop that package once we are at least on PHP 8.0.
+

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "psr/log": "^1.1",
         "symfony/console": "^5.2",
         "symfony/dependency-injection": "^5.2",
+        "symfony/polyfill-php80": "^1.26",
         "symfony/property-access": "^5.3",
         "symfony/property-info": "^5.3",
         "symfony/serializer": "^5.3",


### PR DESCRIPTION
This is deprecated in newer PHP versions, one should use native str_ends_with() instead.

We remove the deprecation by using this function. But we also support older PHP versions, so we add symfony/polyfill-php80 as dependency to always ensure this function exists.