### PR TITLE
Update GitHub checkout action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
   check-composer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Validate composer.json
         run: composer validate
@@ -22,7 +22,7 @@ jobs:
           - 8.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-composer]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -78,7 +78,7 @@ jobs:
       - php-linting
       - xml-linting
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -124,7 +124,7 @@ jobs:
           - php-version: '8.1'
             typo3-version: '^11.5'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -168,7 +168,7 @@ jobs:
             typo3-version: '^11.5'
             db-version: '8'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Necessary as v2 uses old NodeJS which is deprecated.