### PR TITLE
Allow to import configurations via backend module again

### DIFF
--- a/Classes/Controller/Backend/ImportController.php
+++ b/Classes/Controller/Backend/ImportController.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace WerkraumMedia\ThueCat\Controller\Backend;
 
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 use WerkraumMedia\ThueCat\Domain\Import\Importer;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
 use WerkraumMedia\ThueCat\Domain\Repository\Backend\ImportLogRepository;
@@ -72,6 +73,9 @@ class ImportController extends AbstractController
         ]);
     }
 
+    /**
+     * @Extbase\IgnoreValidation("importConfiguration")
+     */
     public function importAction(ImportConfiguration $importConfiguration): void
     {
         $importLog = $this->importer->importConfiguration($importConfiguration);


### PR DESCRIPTION
This broke with introduction of latest import date.
This could not be validated, but we do not need validation anyway and
therefore turn it off.

Relates: #9266