### PR TITLE
Add label for url

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -510,6 +510,11 @@
                 <target>Fotografieren nicht gestattet</target>
             </trans-unit>
 
+            <trans-unit id="content.url">
+                <source>Website</source>
+                <target>Webseite</target>
+            </trans-unit>
+
             <trans-unit id="content.petsAllowed.false">
                 <source>No Pets Allowed</source>
                 <target>Keine Tiere erlaubt</target>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -506,6 +506,10 @@
                         <source>No Pets Allowed</source>
                         <target>Animaux pas autoris&#xE9;s</target>
                   </trans-unit>
+                  <trans-unit id="content.url">
+                      <source>Website</source>
+                      <target>Site internet</target>
+                  </trans-unit>
                   <trans-unit id="content.petsAllowed.true">
                         <source>Pets Allowed</source>
                         <target>Animaux autoris&#xE9;s</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -435,6 +435,10 @@
                 <source>ZeroPhotography</source>
             </trans-unit>
 
+            <trans-unit id="content.url">
+                <source>Website</source>
+            </trans-unit>
+
             <trans-unit id="content.petsAllowed.false">
                 <source>No Pets Allowed</source>
             </trans-unit>

--- a/Resources/Private/Partials/Frontend/ContentElement/Address.html
+++ b/Resources/Private/Partials/Frontend/ContentElement/Address.html
@@ -17,7 +17,7 @@
                 {address.fax}
             </f:if>
             <f:if condition="{url}">
-                <a href="{url}" referrerpolicy="no-referrer" rel="noreferrer noopener">{url}</a>
+                <a href="{url}" referrerpolicy="no-referrer" rel="noreferrer noopener">{f:translate(id: 'content.url', extensionName: 'Thuecat')}</a>
             </f:if>
         </p>
     </div>


### PR DESCRIPTION
Mostlikely URLs should not be rendered but a label "url". This is now added to the extension.