### PR TITLE
Fix PHP Warning

### DIFF
--- a/Classes/Domain/Model/Backend/ImportConfiguration.php
+++ b/Classes/Domain/Model/Backend/ImportConfiguration.php
@@ -95,8 +95,11 @@ class ImportConfiguration extends AbstractEntity implements ImportConfigurationI
 
     public function getLastImported(): ?\DateTimeImmutable
     {
-        $positionOfLastLog = count($this->logs) - 1;
-        $lastImport = $this->logs->offsetGet((string) $positionOfLastLog);
+        $lastImport = null;
+        $positionOfLastLog = (string) (count($this->logs) - 1);
+        if ($this->logs->offsetExists($positionOfLastLog)) {
+            $lastImport = $this->logs->offsetGet($positionOfLastLog);
+        }
         if (!$lastImport instanceof ImportLog) {
             return null;
         }


### PR DESCRIPTION
First check for existence before accessing.
The ObjectStorage itself has no check which will result in an PHP warning due to accessing a none existing array key.

Relates: #10197