### PR TITLE
Allow to hide parking facilities

### DIFF
--- a/Configuration/TCA/tx_thuecat_parking_facility.php
+++ b/Configuration/TCA/tx_thuecat_parking_facility.php
@@ -58,6 +58,21 @@ return (static function (string $extensionKey, string $tableName) {
                     'type' => 'passthrough',
                 ],
             ],
+            'disable' => [
+                'exclude' => true,
+                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.enabled',
+                'config' => [
+                    'type' => 'check',
+                    'renderType' => 'checkboxToggle',
+                    'items' => [
+                        [
+                            0 => '',
+                            1 => '',
+                            'invertStateDisplay' => true
+                        ]
+                    ],
+                ]
+            ],
 
             'title' => [
                 'label' => $languagePath . '.title',
@@ -208,7 +223,7 @@ return (static function (string $extensionKey, string $tableName) {
         ],
         'types' => [
             '0' => [
-                'showitem' => '--palette--;;language, title, description, sanitation, other_service, traffic_infrastructure, payment_accepted, distance_to_public_transport, opening_hours, special_opening_hours, offers, address, media, remote_id, --div--;' . $languagePath . '.tab.relations, town, managed_by',
+                'showitem' => '--palette--;;language, disable, title, description, sanitation, other_service, traffic_infrastructure, payment_accepted, distance_to_public_transport, opening_hours, special_opening_hours, offers, address, media, remote_id, --div--;' . $languagePath . '.tab.relations, town, managed_by',
             ],
         ],
     ];

--- a/Documentation/Changelog/1.3.0.rst
+++ b/Documentation/Changelog/1.3.0.rst
@@ -35,6 +35,8 @@ Features
   We now also filter out the main image from other images, it will not exist twice
   anymore.
 
+* Allow to hide parking facilities.
+
 Fixes
 -----
 


### PR DESCRIPTION
The ctrl configuration already existed, just the corresponding column configuration was missing.
It is now possible to hide and unhide the records within TYPO3 as usual.

Relates: #10230