### PR TITLE
Add closing days

### DIFF
--- a/Classes/Domain/Import/Entity/Place.php
+++ b/Classes/Domain/Import/Entity/Place.php
@@ -29,6 +29,7 @@ use WerkraumMedia\ThueCat\Domain\Import\Entity\Properties\Address;
 use WerkraumMedia\ThueCat\Domain\Import\Entity\Properties\ForeignReference;
 use WerkraumMedia\ThueCat\Domain\Import\Entity\Properties\Geo;
 use WerkraumMedia\ThueCat\Domain\Import\Entity\Properties\OpeningHour;
+use WerkraumMedia\ThueCat\Domain\Import\Entity\Properties\OpeningHourWithRequiredTiming;
 use WerkraumMedia\ThueCat\Domain\Import\Entity\Shared\ContainedInPlace;
 use WerkraumMedia\ThueCat\Domain\Import\Entity\Shared\Organization;
 use WerkraumMedia\ThueCat\Domain\Import\EntityMapper\PropertyValues;
@@ -44,7 +45,7 @@ class Place extends Base
     protected ?Geo $geo = null;
 
     /**
-     * @var OpeningHour[]
+     * @var OpeningHourWithRequiredTiming[]
      */
     protected array $openingHoursSpecifications = [];
 
@@ -143,14 +144,14 @@ class Place extends Base
     }
 
     /**
-     * @return OpeningHour[]
+     * @return OpeningHourWithRequiredTiming[]
      */
     public function getOpeningHoursSpecification(): array
     {
         return GeneralUtility::makeInstance(DateBasedFilter::class)
             ->filterOutPreviousDates(
                 $this->openingHoursSpecifications,
-                function (OpeningHour $hour): ?DateTimeImmutable {
+                function (OpeningHourWithRequiredTiming $hour): ?DateTimeImmutable {
                     return $hour->getValidThrough();
                 }
             )
@@ -201,7 +202,7 @@ class Place extends Base
      */
     public function addOpeningHoursSpecification(OpeningHour $openingHour): void
     {
-        $this->openingHoursSpecifications[] = $openingHour;
+        $this->openingHoursSpecifications[] = OpeningHourWithRequiredTiming::fromOpeningHour($openingHour);
     }
 
     /**

--- a/Classes/Domain/Import/Entity/Properties/OpeningHour.php
+++ b/Classes/Domain/Import/Entity/Properties/OpeningHour.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace WerkraumMedia\ThueCat\Domain\Import\Entity\Properties;
 
 use DateTimeImmutable;
-use WerkraumMedia\ThueCat\Domain\Import\Entity\InvalidDataException;
 
 class OpeningHour
 {
@@ -41,6 +40,11 @@ class OpeningHour
      */
     protected array $daysOfWeek = [];
 
+    public function isClosingDay(): bool
+    {
+        return $this->getOpens() === null && $this->getCloses() === null;
+    }
+
     public function getValidFrom(): ?DateTimeImmutable
     {
         return $this->validFrom;
@@ -51,21 +55,13 @@ class OpeningHour
         return $this->validThrough;
     }
 
-    public function getOpens(): DateTimeImmutable
+    public function getOpens(): ?DateTimeImmutable
     {
-        if ($this->opens === null) {
-            throw new InvalidDataException('Opens was empty for opening hour.');
-        }
-
         return $this->opens;
     }
 
-    public function getCloses(): DateTimeImmutable
+    public function getCloses(): ?DateTimeImmutable
     {
-        if ($this->closes === null) {
-            throw new InvalidDataException('Closes was empty for opening hour.');
-        }
-
         return $this->closes;
     }
 

--- a/Classes/Domain/Import/Entity/Properties/OpeningHourWithRequiredTiming.php
+++ b/Classes/Domain/Import/Entity/Properties/OpeningHourWithRequiredTiming.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2021 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\ThueCat\Domain\Import\Entity\Properties;
+
+use DateTimeImmutable;
+use WerkraumMedia\ThueCat\Domain\Import\Entity\InvalidDataException;
+
+class OpeningHourWithRequiredTiming extends OpeningHour
+{
+    public static function fromOpeningHour(OpeningHour $openingHour): self
+    {
+        $new = new self();
+
+        if ($openingHour->validFrom instanceof DateTimeImmutable) {
+            $new->validFrom = $openingHour->validFrom;
+        }
+        if ($openingHour->validThrough instanceof DateTimeImmutable) {
+            $new->validThrough = $openingHour->validThrough;
+        }
+        if ($openingHour->opens instanceof DateTimeImmutable) {
+            $new->opens = $openingHour->opens;
+        }
+        if ($openingHour->closes instanceof DateTimeImmutable) {
+            $new->closes = $openingHour->closes;
+        }
+        $new->daysOfWeek = $openingHour->daysOfWeek;
+
+        return $new;
+    }
+
+    public function getOpens(): DateTimeImmutable
+    {
+        if ($this->opens === null) {
+            throw new InvalidDataException('Opens was empty for opening hour.');
+        }
+
+        return $this->opens;
+    }
+
+    public function getCloses(): DateTimeImmutable
+    {
+        if ($this->closes === null) {
+            throw new InvalidDataException('Closes was empty for opening hour.');
+        }
+
+        return $this->closes;
+    }
+}

--- a/Classes/Domain/Model/Frontend/MergedOpeningHourWeekDay.php
+++ b/Classes/Domain/Model/Frontend/MergedOpeningHourWeekDay.php
@@ -34,6 +34,11 @@ class MergedOpeningHourWeekDay
     ) {
     }
 
+    public function isClosed(): bool
+    {
+        return $this->opens === '' && $this->closes === '';
+    }
+
     public function getOpens(): string
     {
         return TimingFormat::format($this->opens);

--- a/Classes/Domain/Model/Frontend/Place.php
+++ b/Classes/Domain/Model/Frontend/Place.php
@@ -36,6 +36,8 @@ abstract class Place extends Base
 
     protected ?OpeningHours $specialOpeningHours = null;
 
+    protected ?OpeningHours $closingDays = null;
+
     /**
      * @var ObjectStorage<ParkingFacility>
      */
@@ -107,6 +109,14 @@ abstract class Place extends Base
             return null;
         }
         return $this->specialOpeningHours->getMerged();
+    }
+
+    public function getMergedClosingDays(): ?MergedOpeningHours
+    {
+        if ($this->closingDays === null) {
+            return null;
+        }
+        return $this->closingDays->getMerged();
     }
 
     public function getParkingFacilitiesNearBy(): ObjectStorage

--- a/Configuration/TCA/tx_thuecat_tourist_attraction.php
+++ b/Configuration/TCA/tx_thuecat_tourist_attraction.php
@@ -225,6 +225,14 @@ return (static function (string $extensionKey, string $tableName) {
                     'readOnly' => true,
                 ],
             ],
+            'closing_days' => [
+                'label' => $languagePath . '.closing_days',
+                'l10n_mode' => 'exclude',
+                'config' => [
+                    'type' => 'text',
+                    'readOnly' => true,
+                ],
+            ],
             'address' => [
                 'label' => $languagePath . '.address',
                 'l10n_mode' => 'exclude',
@@ -338,7 +346,7 @@ return (static function (string $extensionKey, string $tableName) {
         ],
         'types' => [
             '0' => [
-                'showitem' => '--palette--;;language, title, description, slogan, start_of_construction, sanitation, other_service, museum_service, architectural_style, traffic_infrastructure, payment_accepted, digital_offer, photography, pets_allowed, is_accessible_for_free, public_access, available_languages, distance_to_public_transport, opening_hours, special_opening_hours, offers, accessibility_specification, address, url, media, remote_id, --div--;' . $languagePath . '.tab.relations, town, managed_by, parking_facility_near_by, --div--;' . $languagePath . '.tab.editorial_additions, editorial_images',
+                'showitem' => '--palette--;;language, title, description, slogan, start_of_construction, sanitation, other_service, museum_service, architectural_style, traffic_infrastructure, payment_accepted, digital_offer, photography, pets_allowed, is_accessible_for_free, public_access, available_languages, distance_to_public_transport, opening_hours, special_opening_hours, closing_days, offers, accessibility_specification, address, url, media, remote_id, --div--;' . $languagePath . '.tab.relations, town, managed_by, parking_facility_near_by, --div--;' . $languagePath . '.tab.editorial_additions, editorial_images',
             ],
         ],
     ];

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -15,6 +15,12 @@ Features
 * Add title to static import configuration.
   This title is auto filled on save with the titles of provided URLs.
 
+* Add closing days.
+  Special opening hours without actual hours are now respected as closing days.
+  Those are imported in a dedicated field.
+
+  The closing days are exposed as new property `mergedClosingDays` in Fluid.
+
 Fixes
 -----
 

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -29,7 +29,7 @@ Nothing
 Tasks
 -----
 
-Nothing
+* Change label `content.specialOpeningHours`.
 
 Deprecation
 -----------

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -35,6 +35,10 @@
                 <source>Public Holidays:</source>
                 <target>Feiertags:</target>
             </trans-unit>
+            <trans-unit id="content.openingHour.closed" xml:space="preserve">
+                <source>Closed</source>
+                <target>geschlossen</target>
+            </trans-unit>
             <trans-unit id="content.price.type.AccommodationOffer" xml:space="preserve">
                 <source>Accommodation Offer</source>
                 <target>Unterkunft</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -105,7 +105,7 @@
             </trans-unit>
             <trans-unit id="content.specialOpeningHours" xml:space="preserve">
                 <source>Special Opening hours</source>
-                <target>Sonderöffnungszeiten</target>
+                <target>abweichende Öffnungszeiten</target>
             </trans-unit>
             <trans-unit id="content.openingHours" xml:space="preserve">
                 <source>Opening hours</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -27,6 +27,9 @@
             <trans-unit id="content.openingHour.weekday.PublicHolidays" xml:space="preserve">
                 <source>Public Holidays:</source>
             </trans-unit>
+            <trans-unit id="content.openingHour.closed" xml:space="preserve">
+                <source>Closed</source>
+            </trans-unit>
             <trans-unit id="module.actions" xml:space="preserve">
                 <source>Actions</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -147,6 +147,9 @@
             <trans-unit id="tx_thuecat_tourist_attraction.special_opening_hours" xml:space="preserve">
                 <source>Special Opening Hours</source>
             </trans-unit>
+            <trans-unit id="tx_thuecat_tourist_attraction.closing_days" xml:space="preserve">
+                <source>Closing Days</source>
+            </trans-unit>
             <trans-unit id="tx_thuecat_tourist_attraction.address" xml:space="preserve">
                 <source>Address</source>
             </trans-unit>

--- a/Tests/Functional/Assertions/Import/ImportsWithSpecialOpeningHoursContainingCloseDays.php
+++ b/Tests/Functional/Assertions/Import/ImportsWithSpecialOpeningHoursContainingCloseDays.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'tx_thuecat_tourist_attraction' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '10',
+            'sys_language_uid' => '0',
+            'l18n_parent' => '0',
+            'l10n_source' => '0',
+            'remote_id' => 'https://thuecat.org/resources/attraction-with-close-days',
+            'title' => 'Contains specialOpeningHoursSpecification with close days',
+            'special_opening_hours' => '[{"opens":"09:30:00","closes":"18:00:00","from":{"date":"2024-09-21 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"through":{"date":"2024-09-21 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"daysOfWeek":["Saturday"]}]',
+            'closing_days' => '[{"from":{"date":"2024-09-20 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"through":{"date":"2024-09-22 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"daysOfWeek":["Friday"]},{"from":{"date":"2024-09-20 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"through":{"date":"2024-09-22 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"daysOfWeek":["Sunday"]}]',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Frontend/ClosingDays.php
+++ b/Tests/Functional/Fixtures/Frontend/ClosingDays.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'tx_thuecat_tourist_attraction' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '10',
+            'sys_language_uid' => '0',
+            'l18n_parent' => '0',
+            'l10n_source' => '0',
+            'remote_id' => 'https://thuecat.org/resources/attraction-with-close-days',
+            'title' => 'Contains specialOpeningHoursSpecification with close days',
+            'closing_days' => '[{"from":{"date":"2024-09-18 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"through":{"date":"2024-09-25 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"daysOfWeek":["Friday"]},{"from":{"date":"2024-09-18 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"through":{"date":"2024-09-25 00:00:00.000000","timezone_type":3,"timezone":"UTC"},"daysOfWeek":["Sunday"]}]',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Frontend/Extensions/example/Classes/TestingDateTimeAspectMiddleware.php
+++ b/Tests/Functional/Fixtures/Frontend/Extensions/example/Classes/TestingDateTimeAspectMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2025 Daniel Siepmann <daniel.siepmann@codappix.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\Example;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
+
+/**
+ * Allows us to set a specific DateTimeAspect for requests within tests.
+ */
+final class TestingDateTimeAspectMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly Context $context,
+    ) {
+    }
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ): ResponseInterface {
+        $testingDateAspect = $request->getAttribute('testingDateAspect');
+        if ($testingDateAspect instanceof DateTimeAspect) {
+            $this->context->setAspect('date', $testingDateAspect);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/Tests/Functional/Fixtures/Frontend/Extensions/example/Configuration/RequestMiddlewares.php
+++ b/Tests/Functional/Fixtures/Frontend/Extensions/example/Configuration/RequestMiddlewares.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use WerkraumMedia\Example\TestingDateTimeAspectMiddleware;
+
+return [
+    'frontend' => [
+        'werkraummedia/example/testing-date-time-aspect' => [
+            'target' => TestingDateTimeAspectMiddleware::class,
+            'before' => [
+                'typo3/cms-frontend/timetracker',
+            ],
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Frontend/Extensions/example/Configuration/Services.php
+++ b/Tests/Functional/Fixtures/Frontend/Extensions/example/Configuration/Services.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) {
+    $services = $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+    ;
+
+    $services->load('WerkraumMedia\\Example\\', '../Classes/*');
+};

--- a/Tests/Functional/Fixtures/Frontend/Extensions/example/Resources/Private/Partials/ContentElement/Opening.html
+++ b/Tests/Functional/Fixtures/Frontend/Extensions/example/Resources/Private/Partials/ContentElement/Opening.html
@@ -10,14 +10,29 @@
                 </f:else>
             </f:if>
             <h3>
-                {openingHour.from -> f:format.date(format: 'd.m.Y')} -
-                {openingHour.through -> f:format.date(format: 'd.m.Y')}
+                {openingHour.from -> f:format.date(format: 'd.m.Y')} - {openingHour.through -> f:format.date(format: 'd.m.Y')}
             </h3>
             <div>
                 <f:for each="{openingHour.daysOfWeekWithMondayFirstWeekDay}" as="weekday">
                     <div class="day-row">
                         <div class="day"><span>{f:translate(id: 'content.openingHour.weekday.{weekday}', default: weekday, extensionName: 'Thuecat')}</span></div>
-                        <div class="time"><span>{openingHour.opens} - {openingHour.closes}</span></div>
+                        <div class="time">
+                            <span>{openingHour.opens} - {openingHour.closes}</span>
+                        </div>
+                    </div>
+                </f:for>
+
+                <f:for each="{openingHour.weekDaysWithMondayFirstWeekDay}" as="day">
+                    <div class="day-row">
+                        {f:translate(
+                            id: 'content.openingHour.weekday.{day.dayOfWeek}',
+                            default: day.dayOfWeek,
+                            extensionName: 'Thuecat'
+                        )} {f:if(
+                            condition: day.closed,
+                            then: '{f:translate(id: "content.openingHour.closed", extensionName: "Thuecat")}',
+                            else: '{day.opens} - {day.closes}'
+                        )}
                     </div>
                 </f:for>
             </div>

--- a/Tests/Functional/Fixtures/Frontend/Extensions/example/Resources/Private/Templates/ContentElement/TouristAttraction.html
+++ b/Tests/Functional/Fixtures/Frontend/Extensions/example/Resources/Private/Templates/ContentElement/TouristAttraction.html
@@ -149,6 +149,13 @@
                         {f:render(partial: 'Opening', arguments: {openingHours: entity.specialOpeningHours})}
                     </div>
                 </f:if>
+
+                <f:if condition="{entity.mergedClosingDays}">
+                    <div class="col-md-6">
+                        <h2>{f:translate(id: 'content.closingDays', extensionName: 'Thuecat')}</h2>
+                        {f:render(partial: 'Opening', arguments: {openingHours: entity.mergedClosingDays})}
+                    </div>
+                </f:if>
             </div>
 
             <div class="thuecat__offers">

--- a/Tests/Functional/Fixtures/Import/Guzzle/thuecat.org/resources/attraction-with-broken-opening-hour.json
+++ b/Tests/Functional/Fixtures/Import/Guzzle/thuecat.org/resources/attraction-with-broken-opening-hour.json
@@ -37,7 +37,7 @@
                     "@value": "thuecat:English"
                 }
             ],
-            "schema:specialOpeningHoursSpecification": [
+            "schema:openingHoursSpecification": [
                 {
                     "@id": "genid-1dccaefc0e06401c93068c8081b7ea8c294892-b11",
                     "@type": [

--- a/Tests/Functional/Fixtures/Import/Guzzle/thuecat.org/resources/attraction-with-close-days.json
+++ b/Tests/Functional/Fixtures/Import/Guzzle/thuecat.org/resources/attraction-with-close-days.json
@@ -1,0 +1,88 @@
+{
+    "@graph": [
+        {
+            "@id": "https://thuecat.org/resources/attraction-with-close-days",
+            "@type": [
+                "schema:TouristAttraction"
+            ],
+            "schema:name": {
+                "@language": "de",
+                "@value": "Contains specialOpeningHoursSpecification with close days"
+            },
+            "schema:availableLanguage": [
+                {
+                    "@type": "thuecat:Language",
+                    "@value": "thuecat:German"
+                },
+                {
+                    "@type": "thuecat:Language",
+                    "@value": "thuecat:English"
+                }
+            ],
+            "schema:specialOpeningHoursSpecification": [
+                {
+                    "@type": [
+                        "schema:OpeningHoursSpecification"
+                    ],
+                    "schema:dayOfWeek": {
+                        "@type": "schema:DayOfWeek",
+                        "@value": "schema:Friday"
+                    },
+                    "schema:validFrom": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-20"
+                    },
+                    "schema:validThrough": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-22"
+                    }
+                },
+                {
+                    "@type": [
+                        "schema:OpeningHoursSpecification"
+                    ],
+                    "schema:dayOfWeek": {
+                        "@type": "schema:DayOfWeek",
+                        "@value": "schema:Sunday"
+                    },
+                    "schema:validFrom": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-20"
+                    },
+                    "schema:validThrough": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-22"
+                    }
+                },
+                {
+                    "@type": [
+                        "schema:OpeningHoursSpecification"
+                    ],
+                    "schema:opens": {
+                        "@type": "schema:Time",
+                        "@value": "09:30:00"
+                    },
+                    "schema:closes": {
+                        "@type": "schema:Time",
+                        "@value": "18:00:00"
+                    },
+                    "schema:dayOfWeek": {
+                        "@type": "schema:DayOfWeek",
+                        "@value": "schema:Saturday"
+                    },
+                    "schema:validFrom": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-21"
+                    },
+                    "schema:validThrough": {
+                        "@type": "schema:Date",
+                        "@value": "2024-09-21"
+                    }
+                }
+            ],
+            "thuecat:contentResponsible": {
+                "@id": "https://thuecat.org/resources/018132452787-ngbe"
+            }
+        }
+    ]
+}

--- a/Tests/Functional/FrontendTest.php
+++ b/Tests/Functional/FrontendTest.php
@@ -26,6 +26,7 @@ namespace WerkraumMedia\ThueCat\Tests\Functional;
 use Codappix\Typo3PhpDatasets\TestingFramework;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -672,6 +673,22 @@ class FrontendTest extends FunctionalTestCase
         $positionSecondHour = mb_strpos($result, $available2->format('d.m.Y'));
 
         self::assertLessThan($positionSecondHour, $positionFirstHour, 'Second hour does not come after first hour.');
+    }
+
+    #[Test]
+    public function closingDaysAreRendered(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/Frontend/ClosingDays.php');
+
+        $request = new InternalRequest();
+        $request = $request->withPageId(2);
+        $request = $request->withAttribute('testingDateAspect', new DateTimeAspect(new DateTimeImmutable('2024-09-21')));
+
+        $result = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        self::assertStringContainsString('18.09.2024 - 25.09.2024', $result);
+        self::assertStringContainsString('Freitag: geschlossen', $result);
+        self::assertStringContainsString('Sonntag: geschlossen', $result);
     }
 
     #[Test]

--- a/Tests/Functional/ImportTest.php
+++ b/Tests/Functional/ImportTest.php
@@ -375,9 +375,9 @@ class ImportTest extends AbstractImportTestCase
 
         $records = $this->getAllRecords('tx_thuecat_tourist_attraction');
         self::assertCount(1, $this->getAllRecords('tx_thuecat_tourist_attraction'));
-        $specialOpeningHours = json_decode($records[0]['special_opening_hours'], true, 512, JSON_THROW_ON_ERROR);
-        self::assertIsArray($specialOpeningHours);
-        self::assertCount(1, $specialOpeningHours);
+        $openingHours = json_decode($records[0]['opening_hours'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($openingHours);
+        self::assertCount(1, $openingHours);
 
         $this->expectErrors = true;
         $loggedErrors = file_get_contents($this->getErrorLogFile());
@@ -387,6 +387,19 @@ class ImportTest extends AbstractImportTestCase
             $loggedErrors
         );
         self::assertStringContainsString('\'closes\' => NULL,', $loggedErrors);
+    }
+
+    #[Test]
+    public function importsWithSpecialOpeningHoursContainingCloseDays(): void
+    {
+        $this->importPHPDataSet(__DIR__ . '/Fixtures/Import/ImportsWithBrokenOpeningHour.php');
+
+        GuzzleClientFaker::appendResponseFromFile(__DIR__ . '/Fixtures/Import/Guzzle/thuecat.org/resources/attraction-with-close-days.json');
+        GuzzleClientFaker::appendResponseFromFile(__DIR__ . '/Fixtures/Import/Guzzle/thuecat.org/resources/018132452787-ngbe.json');
+
+        $this->importConfiguration();
+
+        $this->assertPHPDataSet(__DIR__ . '/Assertions/Import/ImportsWithSpecialOpeningHoursContainingCloseDays.php');
     }
 
     private function importConfiguration(): void

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "WerkraumMedia\\ThueCat\\Tests\\": "Tests/"
+            "WerkraumMedia\\ThueCat\\Tests\\": "Tests/",
+            "WerkraumMedia\\Example\\": "Tests/Functional/Fixtures/Frontend/Extensions/example/Classes/"
         }
     },
     "require": {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -58,6 +58,7 @@ CREATE TABLE tx_thuecat_tourist_attraction (
     description text,
     opening_hours text,
     special_opening_hours text,
+    closing_days text,
     address text,
     url text,
     media text,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,3 +12,6 @@ parameters:
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: true
     checkGenericClassInNonGenericObjectType: false
+    typo3:
+      requestGetAttributeMapping:
+        testingDateAspect: 'TYPO3\CMS\Core\Context\DateTimeAspect'


### PR DESCRIPTION
Special opening hours without actual hours are now respected as closing days.  Those are imported in a dedicated field. This allows special handling in frontend.

Relates: #11518