### PR TITLE
Handle 404 for configured resources

### DIFF
--- a/Classes/Domain/Model/Backend/ImportLogEntry/FetchingError.php
+++ b/Classes/Domain/Model/Backend/ImportLogEntry/FetchingError.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2025 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry;
+
+use Exception;
+use WerkraumMedia\ThueCat\Domain\Import\Importer\FetchData\InvalidResponseException;
+use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry;
+
+final class FetchingError extends ImportLogEntry
+{
+    protected string $remoteId = '';
+
+    /**
+     * Necessary for Extbase/Symfony.
+     *
+     * @var string
+     */
+    protected string $errors = '[]';
+
+    public function __construct(
+        string $url,
+        InvalidResponseException $exception
+    ) {
+        $this->remoteId = $url;
+        $this->errors = json_encode([$exception->getMessage()], JSON_THROW_ON_ERROR) ?: '';
+    }
+
+    public function getRemoteId(): string
+    {
+        return $this->remoteId;
+    }
+
+    public function getErrors(): array
+    {
+        $errors = json_decode($this->errors, true);
+        if (is_array($errors) === false) {
+            throw new Exception('Could not parse errors.', 1671097690);
+        }
+        return $errors;
+    }
+
+    public function hasErrors(): bool
+    {
+        return true;
+    }
+
+    public function getType(): string
+    {
+        return 'fetchingError';
+    }
+
+    public function getInsertion(): array
+    {
+        return [];
+    }
+}

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportConfiguration;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLog;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry;
+use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry\FetchingError;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry\MappingError;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\ImportLogEntry\SavingEntity;
 use WerkraumMedia\ThueCat\Domain\Model\Backend\Organisation;
@@ -39,6 +40,7 @@ return [
         'subclasses' => [
             'savingEntity' => SavingEntity::class,
             'mappingError' => MappingError::class,
+            'fetchingError' => FetchingError::class,
         ],
     ],
     SavingEntity::class => [
@@ -48,6 +50,10 @@ return [
     MappingError::class => [
         'tableName' => 'tx_thuecat_import_log_entry',
         'recordType' => 'mappingError',
+    ],
+    FetchingError::class => [
+        'tableName' => 'tx_thuecat_import_log_entry',
+        'recordType' => 'fetchingError',
     ],
 
     FrontendTouristAttraction::class => [

--- a/Configuration/TCA/tx_thuecat_import_log_entry.php
+++ b/Configuration/TCA/tx_thuecat_import_log_entry.php
@@ -42,6 +42,10 @@ return (static function (string $extensionKey, string $tableName) {
                             'label' => $languagePath . '.type.mappingError',
                             'value' => 'mappingError',
                         ],
+                        [
+                            'label' => $languagePath . '.type.fetchingError',
+                            'value' => 'fetchingError',
+                        ],
                     ],
                 ],
             ],
@@ -116,6 +120,9 @@ return (static function (string $extensionKey, string $tableName) {
                 'showitem' => '--palette--;;always, table_name, record_uid, insertion, errors',
             ],
             'mappingError' => [
+                'showitem' => '--palette--;;always, errors',
+            ],
+            'fetchingError' => [
                 'showitem' => '--palette--;;always, errors',
             ],
         ],

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -25,6 +25,10 @@ Fixes
   The corresponding core change was commit `45a50e455955c78f6baa2aec3af3865101ee06b9`.
   We also need to update `codappix/typo3-php-datasets` dev dependency for the same reason.
 
+* Handle 404 during import.
+  Imports that would import a no longer existing resource resulted in a 503 Server Error.
+  Those are now properly catched and logged. Those errors will no longer fail.
+
 Tasks
 -----
 

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -280,6 +280,9 @@
             <trans-unit id="tx_thuecat_import_log_entry.type.mappingError" xml:space="preserve">
                 <source>Mapping Error</source>
             </trans-unit>
+            <trans-unit id="tx_thuecat_import_log_entry.type.fetchingError" xml:space="preserve">
+                <source>Fetching Error</source>
+            </trans-unit>
             <trans-unit id="tx_thuecat_import_log_entry.remote_id" xml:space="preserve">
                 <source>Remote ID (URL)</source>
             </trans-unit>

--- a/Tests/Functional/Fixtures/Import/Import404Resource.php
+++ b/Tests/Functional/Fixtures/Import/Import404Resource.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+
+return [
+    'pages' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '0',
+            'tstamp' => '1613400587',
+            'crdate' => '1613400558',
+            'doktype' => PageRepository::DOKTYPE_DEFAULT,
+            'title' => 'Rootpage',
+            'is_siteroot' => '1',
+        ],
+        1 => [
+            'uid' => '10',
+            'pid' => '1',
+            'tstamp' => '1613400587',
+            'crdate' => '1613400558',
+            'doktype' => PageRepository::DOKTYPE_SYSFOLDER,
+            'title' => 'Storage folder',
+        ],
+    ],
+    'tx_thuecat_import_configuration' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '0',
+            'tstamp' => '1613400587',
+            'crdate' => '1613400558',
+            'disable' => '0',
+            'title' => 'Contains Place',
+            'type' => 'static',
+            'configuration' => '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+            <T3FlexForms>
+                <data>
+                    <sheet index="sDEF">
+                        <language index="lDEF">
+                            <field index="storagePid">
+                                <value index="vDEF">10</value>
+                            </field>
+                            <field index="urls">
+                                <el index="el">
+                                    <field index="669682c1be71a690875453">
+                                        <value index="url">
+                                            <el>
+                                                <field index="url">
+                                                    <value index="vDEF">https://thuecat.org/resources/831770160143-anfc</value>
+                                                </field>
+                                            </el>
+                                        </value>
+                                        <value index="_TOGGLE">0</value>
+                                    </field>
+                                </el>
+                            </field>
+                        </language>
+                    </sheet>
+                </data>
+            </T3FlexForms>',
+        ],
+    ],
+];


### PR DESCRIPTION
They previously ended in a 503 server error.
We now catch the exception and convert it into a log entry. It is logged into TYPO3 logging framework and import log.

That way triggering the import will result in a flash message showing the import didn't fully work.

Resolves: #12295