### PR TITLE
Fix compatibliity issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,13 @@ jobs:
           - php-version: '8.3'
             typo3-version: '^12.4'
           - php-version: '8.2'
-            typo3-version: '^13.4'
+            typo3-version: '^13.4.18'
           - php-version: '8.3'
-            typo3-version: '^13.4'
+            typo3-version: '^13.4.18'
+          - php-version: '8.2'
+            typo3-version: '^13.4.19'
+          - php-version: '8.3'
+            typo3-version: '^13.4.19'
     steps:
       - uses: actions/checkout@v3
 
@@ -129,10 +133,16 @@ jobs:
             typo3-version: '^12.4'
             db-version: '8'
           - php-version: '8.2'
-            typo3-version: '^13.4'
+            typo3-version: '^13.4.18'
             db-version: '8'
           - php-version: '8.3'
-            typo3-version: '^13.4'
+            typo3-version: '^13.4.18'
+            db-version: '8'
+          - php-version: '8.2'
+            typo3-version: '^13.4.19'
+            db-version: '8'
+          - php-version: '8.3'
+            typo3-version: '^13.4.19'
             db-version: '8'
     steps:
       - uses: actions/checkout@v3

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -27,6 +27,8 @@ Tasks
   As this is an extension without a lock state.
   We have different TYPO3 versions as supported versions and it should be easy to switch between them for testing and development.
 
+* Streamline `phpstan.neon` formatting.
+
 Deprecation
 -----------
 

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -23,7 +23,9 @@ Nothing
 Tasks
 -----
 
-Nothing
+* Prevent creation of `composer.lock` file.
+  As this is an extension without a lock state.
+  We have different TYPO3 versions as supported versions and it should be easy to switch between them for testing and development.
 
 Deprecation
 -----------

--- a/Documentation/Changelog/4.1.0.rst
+++ b/Documentation/Changelog/4.1.0.rst
@@ -18,7 +18,12 @@ Features
 Fixes
 -----
 
-Nothing
+* Prevent `Error: Call to undefined method TYPO3\CMS\Core\Database\Schema\SchemaInformation::introspectTable()` with newer TYPO3 v13 versions.
+  We now check for the old API, falling back to the new.
+  All of this is still `@internal` TYPO3 API.
+
+  The corresponding core change was commit `45a50e455955c78f6baa2aec3af3865101ee06b9`.
+  We also need to update `codappix/typo3-php-datasets` dev dependency for the same reason.
 
 Tasks
 -----

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "typo3/cms-install": "^12.4 || ^13.4"
     },
     "require-dev": {
-        "codappix/typo3-php-datasets": "^1.4",
+        "codappix/typo3-php-datasets": "^1.4 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.40",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "1.10.46",

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     },
     "config": {
         "sort-packages": true,
+        "lock": false,
         "allow-plugins": {
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,3 +12,5 @@ parameters:
   checkMissingIterableValueType: false
   reportUnmatchedIgnoredErrors: true
   checkGenericClassInNonGenericObjectType: false
+  ignoreErrors:
+    - message: "#^Call to function method_exists\\(\\) with .* will always evaluate to false\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,14 +1,14 @@
 includes:
-    - phpstan-baseline.neon
+  - 'phpstan-baseline.neon'
 parameters:
-    level: max
-    paths:
-        - Classes
-        - Configuration
-        - Tests
-    excludePaths:
-      - Tests/Acceptance/Support/_generated/
-      - Classes/Domain/Import/EntityMapper/CustomAnnotationExtractor.php
-    checkMissingIterableValueType: false
-    reportUnmatchedIgnoredErrors: true
-    checkGenericClassInNonGenericObjectType: false
+  level: 'max'
+  paths:
+    - 'Classes'
+    - 'Configuration'
+    - 'Tests'
+  excludePaths:
+    - 'Tests/Acceptance/Support/_generated/'
+    - 'Classes/Domain/Import/EntityMapper/CustomAnnotationExtractor.php'
+  checkMissingIterableValueType: false
+  reportUnmatchedIgnoredErrors: true
+  checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
Prevent creation of `composer.lock` file

As this is an extension without a lock state.
We have different TYPO3 versions as supported versions and it should be easy to switch between them for testing and development.

Prevent `Error: Call to undefined method introspectTable()`

We now require v13.4.19 at least, as this removed the methods and
introduced something new.
All of this is still `@internal` TYPO3 API.

The corresponding core change was commit
`45a50e455955c78f6baa2aec3af3865101ee06b9`.

Relates: #12295